### PR TITLE
[codex] immediately resolve instance-associated subtype arguments

### DIFF
--- a/compiler/semantic/solver/src/subtype/application.rs
+++ b/compiler/semantic/solver/src/subtype/application.rs
@@ -37,28 +37,6 @@ impl Solver<'_> {
         greater_ap: &Application,
         variance: Variance,
     ) -> Result<Option<Step>, OverflowError> {
-        // URGENT: We shouldn't allow destructuring the instance-associated.
-        // Okay, instance-associated types are analogous to trait-associated
-        // types right? So, I'll explain it here.
-        //
-        // Imagine we have trait named `Col` with an associated type `Elm`.
-        // Let's say we have a relation `Col.Elm[Set[Int32]] ~
-        // Col.Elm[Vec[Int32]]`. If we destructure this relation, we'll get
-        // `Set[Int32] ~ Vec[Int32]` as a subgoal, which will never be solvable.
-        //
-        // This is because, we'll never know that after reduction, the
-        // `Col.Elm[Set[Int32]]` and `Col.Elm[Vec[Int32]]` will reduce to the
-        // same type, and since we have break down the relation into
-        // `Set[Int32] ~ Vec[Int32]`, we'll lose the information that they might
-        // reduce to the same type.
-        //
-        // On second thought, I'm not saying we shouldn't allow destructuring
-        // instance-associated types at all, but we should fix the "loss of
-        // information" issue.
-        //
-        // One immediate fix that comes to mind is to, resolve the sub-problems
-        // immediately so that we don't lose the information that there're
-        // instance-associated types involved.
         let Some(iter) = lesser_ap.destructure(greater_ap, self.engine())
         else {
             return Box::pin(self.try_reduce(lesser, greater, variance)).await;
@@ -79,11 +57,29 @@ impl Solver<'_> {
             ))
             .await
         } else {
+            // A failed argument subproblem must fail the destructuring of an
+            // instance-associated application. Deferring it would discard the
+            // enclosing application, which may still be reducible as a whole.
+            let resolve_strategy = match lesser_ap.constructor() {
+                Constructor::InstanceAssociated(_) => {
+                    ResolveStrategy::ResolveImmediately
+                }
+                Constructor::Primitive(_)
+                | Constructor::Lifetime(_)
+                | Constructor::Reference(_)
+                | Constructor::Symbolic(_)
+                | Constructor::Tuple(_)
+                | Constructor::FunctionPointer(_)
+                | Constructor::AnonymousTraitInstance(_) => {
+                    ResolveStrategy::DeferResolution
+                }
+            };
+
             Box::pin(self.handle_application_arguments(
                 lesser_ap,
                 arguments.into_iter(),
                 variance,
-                ResolveStrategy::DeferResolution,
+                resolve_strategy,
             ))
             .await
         }

--- a/compiler/semantic/solver/src/subtype/application.rs
+++ b/compiler/semantic/solver/src/subtype/application.rs
@@ -57,9 +57,24 @@ impl Solver<'_> {
             ))
             .await
         } else {
-            // A failed argument subproblem must fail the destructuring of an
-            // instance-associated application. Deferring it would discard the
-            // enclosing application, which may still be reducible as a whole.
+            // Instance-associated applications may reduce to the same type
+            // even when their corresponding arguments are not subtypes. For
+            // example, consider a trait `Col` with an associated type `Elm`
+            // and the relation:
+            //
+            // `Col.Elm[Set[Int32]] <: Col.Elm[Vec[Int32]]`
+            //
+            // Both associated types may reduce to `Int32`, so the relation can
+            // hold even though `Set[Int32] <: Vec[Int32]` does not.
+            //
+            // If the applications were destructured and that argument
+            // subproblem were deferred, the enclosing associated applications
+            // would be discarded. The solver would then only retain the
+            // unsolvable `Set[Int32] <: Vec[Int32]` subproblem and lose the
+            // opportunity to reduce the original associated types.
+            // Therefore every argument subproblem must solve immediately; if
+            // one is stuck, destructuring fails and the caller retains the
+            // original relation for a later reduction attempt.
             let resolve_strategy = match lesser_ap.constructor() {
                 Constructor::InstanceAssociated(_) => {
                     ResolveStrategy::ResolveImmediately

--- a/compiler/semantic/solver/src/subtype/test.rs
+++ b/compiler/semantic/solver/src/subtype/test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use pernixc_qbice::{Engine, InMemoryFactory, TrackedEngine};
+use pernixc_symbol::GlobalSymbolID;
 use pernixc_type::{
     predicate::Subtype,
     substitution::Substitution,
@@ -8,8 +9,8 @@ use pernixc_type::{
         Type,
         bound::{Binder, BoundVariable},
         constructor::{
-            Application, Constructor, FunctionPointer, Lifetime, Mutability,
-            Primitive, Reference, Tuple,
+            Application, Constructor, FunctionPointer, InstanceAssociated,
+            Lifetime, Mutability, Primitive, Reference, Tuple,
         },
         kind::TyKind,
     },
@@ -94,6 +95,41 @@ fn function_pointer(
     )))
 }
 
+fn instance_associated(
+    arguments: Vec<Interned<Type>>,
+    engine: &TrackedEngine,
+) -> Interned<Type> {
+    engine.intern(Type::Application(Application::new(
+        Constructor::InstanceAssociated(InstanceAssociated::new(
+            GlobalSymbolID::default(),
+        )),
+        engine.intern_unsized(arguments),
+    )))
+}
+
+async fn destructure_application(
+    lesser: &Interned<Type>,
+    greater: &Interned<Type>,
+    engine: &TrackedEngine,
+) -> Result<Option<Step>, OverflowError> {
+    let Type::Application(lesser_application) = &**lesser else {
+        panic!("expected application");
+    };
+    let Type::Application(greater_application) = &**greater else {
+        panic!("expected application");
+    };
+
+    Solver::new(&Premise::default(), engine)
+        .handle_application(
+            lesser,
+            greater,
+            lesser_application,
+            greater_application,
+            Variance::Covariant,
+        )
+        .await
+}
+
 async fn resolve_one(
     lesser: Interned<Type>,
     greater: Interned<Type>,
@@ -146,6 +182,54 @@ fn assert_no_variables_in_step(
         !contains_variable(constraint.lesser())
             && !contains_variable(constraint.greater())
     }));
+}
+
+#[tokio::test]
+async fn instance_associated_arguments_must_be_solved_immediately() {
+    let engine = create_engine().await;
+    let common_instance = primitive(Primitive::Bool, &engine);
+    let lesser = instance_associated(
+        vec![common_instance.clone(), primitive(Primitive::Int32, &engine)],
+        &engine,
+    );
+    let greater = instance_associated(
+        vec![common_instance, primitive(Primitive::Float32, &engine)],
+        &engine,
+    );
+
+    assert_eq!(
+        destructure_application(&lesser, &greater, &engine).await.unwrap(),
+        None
+    );
+}
+
+#[tokio::test]
+async fn solved_instance_associated_arguments_are_not_deferred() {
+    let engine = create_engine().await;
+    let common_instance = primitive(Primitive::Bool, &engine);
+    let static_lifetime = lifetime(Lifetime::Static, &engine);
+    let erased_lifetime = lifetime(Lifetime::Erased, &engine);
+    let lesser = instance_associated(
+        vec![common_instance.clone(), static_lifetime.clone()],
+        &engine,
+    );
+    let greater = instance_associated(
+        vec![common_instance, erased_lifetime.clone()],
+        &engine,
+    );
+
+    let (substitution, residual_subtypes, constraints) =
+        destructure_application(&lesser, &greater, &engine)
+            .await
+            .unwrap()
+            .expect("arguments should solve immediately");
+
+    assert_eq!(substitution, Substitution::new());
+    assert_eq!(residual_subtypes, Vec::new());
+    assert_eq!(
+        constraints,
+        Constraints::lifetimes_eq(static_lifetime, erased_lifetime)
+    );
 }
 
 // input: ('static) <: ('erased) @ Covariant

--- a/compiler/semantic/type/src/type/constructor.rs
+++ b/compiler/semantic/type/src/type/constructor.rs
@@ -221,6 +221,11 @@ pub struct InstanceAssociated {
 
 impl InstanceAssociated {
     #[must_use]
+    pub const fn new(trait_associated_id: GlobalSymbolID) -> Self {
+        Self { trait_associated_id }
+    }
+
+    #[must_use]
     pub const fn trait_associated_id(&self) -> GlobalSymbolID {
         self.trait_associated_id
     }


### PR DESCRIPTION
## Summary

- require destructured instance-associated subtype arguments to resolve immediately
- preserve the enclosing associated-type relation when an argument is stuck, allowing later reduction
- add focused unit tests for successful and unsuccessful immediate resolution
- document the `Col.Elm[Set[Int32]]` versus `Col.Elm[Vec[Int32]]` information-loss case

## Root cause

All non-HRTB type applications previously deferred their destructured subtype arguments. For instance-associated applications, deferral discarded the enclosing relation even though both associated types could later reduce to the same type.

## Impact

Instance-associated subtype relations no longer become irrecoverably stuck solely because their underlying instance arguments are unrelated.

## Validation

- `cargo test -p pernixc_solver subtype::test`
- `cargo clippy -p pernixc_solver --tests -- -D warnings`
- `cargo +nightly fmt`
- `git diff --check`
