### PR TITLE
[codex] implement symbolic outlives solving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,9 +1932,11 @@ name = "pernixc_solver"
 version = "0.1.0-beta.2"
 dependencies = [
  "enum-as-inner",
+ "pernixc_arena",
  "pernixc_hash",
  "pernixc_qbice",
  "pernixc_symbol",
+ "pernixc_target",
  "pernixc_type",
  "qbice",
  "thiserror 2.0.18",

--- a/compiler/semantic/solver/Cargo.toml
+++ b/compiler/semantic/solver/Cargo.toml
@@ -17,6 +17,8 @@ thiserror.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true
+pernixc_arena.path = "../../base/arena"
+pernixc_target.path = "../../base/target"
 
 [lints]
 workspace = true

--- a/compiler/semantic/solver/src/lib.rs
+++ b/compiler/semantic/solver/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod constraints;
 pub mod r#match;
+pub mod outlives;
 pub mod premise;
 pub mod reduction;
 pub mod solver;

--- a/compiler/semantic/solver/src/outlives.rs
+++ b/compiler/semantic/solver/src/outlives.rs
@@ -1,0 +1,297 @@
+use std::future::Future;
+
+use pernixc_type::{
+    predicate::{Outlives, Predicate},
+    r#type::{
+        Type,
+        constructor::{Constructor, Lifetime},
+    },
+};
+use qbice::storage::intern::Interned;
+
+use crate::{
+    constraints::Constraints,
+    solver::{OverflowError, Provisional, Solve, Solver},
+};
+
+impl Solve for Outlives {
+    type Result = bool;
+
+    async fn solve(
+        &self,
+        solver: &mut Solver<'_>,
+    ) -> Result<Self::Result, OverflowError> {
+        solver.solve_outlives(self).await
+    }
+
+    fn provisional_result(&self) -> Provisional<Self::Result> {
+        Provisional::Continue(false)
+    }
+}
+
+impl Solver<'_> {
+    /// Returns whether `outlives` is derivable from the current premise.
+    ///
+    /// A `false` result means that no proof was found. It does not establish
+    /// the negation of the relation.
+    pub async fn outlives(
+        &mut self,
+        outlives: &Outlives,
+    ) -> Result<bool, OverflowError> {
+        self.solve(outlives).await
+    }
+
+    #[allow(clippy::manual_async_fn)]
+    fn solve_outlives<'a>(
+        &'a mut self,
+        outlives: &'a Outlives,
+    ) -> impl Future<Output = Result<bool, OverflowError>> + Send + 'a {
+        async move {
+            // The outlives relation is reflexive.
+            if outlives.lesser() == outlives.greater() {
+                return Ok(true);
+            }
+
+            // `'static` outlives every lifetime.
+            if is_static_lifetime(outlives.lesser()) {
+                return Ok(true);
+            }
+
+            // Search the premise graph for a direct or transitive proof.
+            if self.outlives_from_premise(outlives).await? {
+                return Ok(true);
+            }
+
+            match &**outlives.lesser() {
+                Type::Application(application) => {
+                    match application.constructor() {
+                        Constructor::InstanceAssociated(_) => {
+                            self.instance_associated_outlives(outlives).await
+                        }
+
+                        Constructor::Lifetime(_) => Ok(false),
+
+                        Constructor::Primitive(_)
+                        | Constructor::Reference(_)
+                        | Constructor::Symbolic(_)
+                        | Constructor::Tuple(_)
+                        | Constructor::FunctionPointer(_)
+                        | Constructor::AnonymousTraitInstance(_) => {
+                            self.all_components_outlive(
+                                outlives_components(outlives.lesser()),
+                                outlives.greater(),
+                            )
+                            .await
+                        }
+                    }
+                }
+
+                Type::GenericParameter(_)
+                | Type::InferenceVariable(_)
+                | Type::BoundVariable(_)
+                | Type::SkolemizedVariable(_) => Ok(false),
+            }
+        }
+    }
+
+    async fn outlives_from_premise(
+        &mut self,
+        goal: &Outlives,
+    ) -> Result<bool, OverflowError> {
+        let lesser_is_lifetime =
+            self.kind_of(goal.lesser()).await.is_lifetime();
+
+        for predicate in self.premise_predicates() {
+            let Predicate::Outlives(premise) = predicate else {
+                continue;
+            };
+
+            assert!(
+                !contains_inference_variable(premise.lesser())
+                    && !contains_inference_variable(premise.greater()),
+                "outlives premises must not contain inference variables"
+            );
+
+            for component in outlives_components(premise.lesser()) {
+                if lesser_is_lifetime {
+                    // Lifetime premises form graph edges. Matching distinct
+                    // lifetimes with `match_types` would emit equality edges
+                    // in both directions and make transitive lookup blow up.
+                    if component != *goal.lesser() {
+                        continue;
+                    }
+                } else {
+                    let Some((substitution, constraints)) =
+                        self.match_types(&component, goal.lesser()).await
+                    else {
+                        continue;
+                    };
+
+                    // Outlives premises are fully symbolic givens, not
+                    // patterns. In particular, they must not contain
+                    // inference variables that `match_types` could bind
+                    // without returning that binding to the caller of this
+                    // boolean query.
+                    assert!(
+                        substitution.iter().next().is_none(),
+                        "outlives premises must not contain inference \
+                         variables"
+                    );
+
+                    if !self.all_constraints_hold(constraints).await? {
+                        continue;
+                    }
+                }
+
+                if Box::pin(self.solve(&Outlives::new(
+                    premise.greater().clone(),
+                    goal.greater().clone(),
+                )))
+                .await?
+                {
+                    return Ok(true);
+                }
+            }
+        }
+
+        Ok(false)
+    }
+
+    async fn instance_associated_outlives(
+        &mut self,
+        outlives: &Outlives,
+    ) -> Result<bool, OverflowError> {
+        if let Some((reduced, constraints)) =
+            self.reduce_type(outlives.lesser().clone()).await?
+            && self.all_constraints_hold(constraints).await?
+            && Box::pin(
+                self.solve(&Outlives::new(reduced, outlives.greater().clone())),
+            )
+            .await?
+        {
+            return Ok(true);
+        }
+
+        let Type::Application(application) = &**outlives.lesser() else {
+            unreachable!("the caller only passes instance-associated types");
+        };
+
+        let components = application
+            .arguments()
+            .iter()
+            .flat_map(outlives_components)
+            .collect::<Vec<_>>();
+
+        self.all_components_outlive(components, outlives.greater()).await
+    }
+
+    async fn all_components_outlive(
+        &mut self,
+        components: impl IntoIterator<Item = Interned<Type>>,
+        greater: &Interned<Type>,
+    ) -> Result<bool, OverflowError> {
+        for component in components {
+            if !Box::pin(self.solve(&Outlives::new(component, greater.clone())))
+                .await?
+            {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    async fn all_constraints_hold(
+        &mut self,
+        constraints: Constraints,
+    ) -> Result<bool, OverflowError> {
+        for constraint in constraints {
+            if !Box::pin(self.solve(&constraint)).await? {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+fn outlives_components(ty: &Interned<Type>) -> Vec<Interned<Type>> {
+    let mut components = Vec::new();
+    push_outlives_components(ty, 0, &mut components);
+    components
+}
+
+fn push_outlives_components(
+    ty: &Interned<Type>,
+    binder_depth: usize,
+    components: &mut Vec<Interned<Type>>,
+) {
+    match &**ty {
+        Type::GenericParameter(_)
+        | Type::InferenceVariable(_)
+        | Type::SkolemizedVariable(_) => components.push(ty.clone()),
+
+        Type::BoundVariable(variable) => {
+            assert!(
+                variable.depth() < binder_depth,
+                "outlives component traversal found an escaping bound variable"
+            );
+        }
+
+        Type::Application(application) => match application.constructor() {
+            Constructor::Lifetime(_) | Constructor::InstanceAssociated(_) => {
+                components.push(ty.clone());
+            }
+
+            Constructor::FunctionPointer(_) => {
+                for argument in application.arguments().iter() {
+                    push_outlives_components(
+                        argument,
+                        binder_depth + 1,
+                        components,
+                    );
+                }
+            }
+
+            Constructor::Primitive(_)
+            | Constructor::Reference(_)
+            | Constructor::Symbolic(_)
+            | Constructor::Tuple(_)
+            | Constructor::AnonymousTraitInstance(_) => {
+                for argument in application.arguments().iter() {
+                    push_outlives_components(
+                        argument,
+                        binder_depth,
+                        components,
+                    );
+                }
+            }
+        },
+    }
+}
+
+const fn is_static_lifetime(ty: &Type) -> bool {
+    matches!(
+        ty,
+        Type::Application(application)
+            if matches!(
+                application.constructor(),
+                Constructor::Lifetime(Lifetime::Static)
+            )
+    )
+}
+
+fn contains_inference_variable(ty: &Interned<Type>) -> bool {
+    match &**ty {
+        Type::InferenceVariable(_) => true,
+        Type::Application(application) => {
+            application.arguments().iter().any(contains_inference_variable)
+        }
+        Type::GenericParameter(_)
+        | Type::BoundVariable(_)
+        | Type::SkolemizedVariable(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/compiler/semantic/solver/src/outlives/test.rs
+++ b/compiler/semantic/solver/src/outlives/test.rs
@@ -1,0 +1,552 @@
+use std::sync::Arc;
+
+use pernixc_arena::ID;
+use pernixc_qbice::{Config, Engine, InMemoryFactory, TrackedEngine};
+use pernixc_symbol::{GlobalSymbolID, SymbolID, kind::Kind};
+use pernixc_target::TargetID;
+use pernixc_type::{
+    generic_parameters::{
+        self, GenericParameter, GenericParameterID, GenericParameterKind,
+        GenericParameters, InstanceParameterKind,
+    },
+    predicate::{Equality, Outlives, Predicate},
+    r#type::{
+        Type,
+        bound::{Binder, BoundVariable},
+        constructor::{
+            AnonymousTraitInstance, Application, Constructor, FunctionPointer,
+            InstanceAssociated, Lifetime, Mutability, Primitive, Reference,
+            Symbolic, Tuple,
+        },
+        kind::TyKind,
+    },
+};
+use qbice::{
+    executor, serialize::Plugin, stable_hash::SeededStableHasherBuilder,
+    storage::intern::Interned,
+};
+
+use crate::{premise::Premise, solver::Solver};
+
+const LIFETIME_SYMBOL_ID: GlobalSymbolID =
+    TargetID::TEST.make_global(SymbolID::from_u128(1));
+const TYPE_SYMBOL_ID: GlobalSymbolID =
+    TargetID::TEST.make_global(SymbolID::from_u128(2));
+const INSTANCE_SYMBOL_ID: GlobalSymbolID =
+    TargetID::TEST.make_global(SymbolID::from_u128(3));
+const TRAIT_ID: GlobalSymbolID =
+    TargetID::TEST.make_global(SymbolID::from_u128(4));
+const ASSOCIATED_ID: GlobalSymbolID =
+    TargetID::TEST.make_global(SymbolID::from_u128(5));
+
+struct GenericParametersExecutor;
+
+impl executor::Executor<generic_parameters::Key, Config>
+    for GenericParametersExecutor
+{
+    async fn execute(
+        &self,
+        key: &generic_parameters::Key,
+        engine: &TrackedEngine,
+    ) -> Interned<GenericParameters> {
+        let kind = match key.symbol_id {
+            LIFETIME_SYMBOL_ID => GenericParameterKind::Lifetime,
+            TYPE_SYMBOL_ID => GenericParameterKind::Type,
+            INSTANCE_SYMBOL_ID => {
+                GenericParameterKind::Instance(InstanceParameterKind::new(None))
+            }
+            _ => panic!("unexpected generic parameter owner"),
+        };
+
+        engine.intern(GenericParameters::new((0..16).map(|index| {
+            GenericParameter::new(
+                engine.intern_unsized(format!("T{index}")),
+                None,
+                kind.clone(),
+            )
+        })))
+    }
+}
+
+struct KindExecutor;
+
+impl executor::Executor<pernixc_symbol::kind::Key, Config> for KindExecutor {
+    async fn execute(
+        &self,
+        key: &pernixc_symbol::kind::Key,
+        _: &TrackedEngine,
+    ) -> Kind {
+        match key.symbol_id {
+            TYPE_SYMBOL_ID => Kind::Struct,
+            INSTANCE_SYMBOL_ID => Kind::Instance,
+            TRAIT_ID => Kind::Trait,
+            ASSOCIATED_ID => Kind::InstanceAssociatedType,
+            LIFETIME_SYMBOL_ID => {
+                panic!("a generic parameter owner has no type constructor")
+            }
+            _ => panic!("unexpected kind lookup"),
+        }
+    }
+}
+
+async fn create_engine() -> TrackedEngine {
+    let mut engine = Engine::new_with(
+        Plugin::default(),
+        InMemoryFactory,
+        SeededStableHasherBuilder::new(0),
+    )
+    .await
+    .unwrap();
+
+    engine.register_executor(Arc::new(GenericParametersExecutor));
+    engine.register_executor(Arc::new(KindExecutor));
+
+    Arc::new(engine).tracked().await
+}
+
+fn application(
+    constructor: Constructor,
+    arguments: impl IntoIterator<Item = Interned<Type>>,
+    engine: &TrackedEngine,
+) -> Interned<Type> {
+    engine.intern(Type::Application(Application::new(
+        constructor,
+        engine.intern_unsized(arguments.into_iter().collect::<Vec<_>>()),
+    )))
+}
+
+fn primitive(primitive: Primitive, engine: &TrackedEngine) -> Interned<Type> {
+    application(Constructor::Primitive(primitive), [], engine)
+}
+
+fn lifetime(lifetime: Lifetime, engine: &TrackedEngine) -> Interned<Type> {
+    application(Constructor::Lifetime(lifetime), [], engine)
+}
+
+fn generic(
+    owner: GlobalSymbolID,
+    index: u64,
+    engine: &TrackedEngine,
+) -> Interned<Type> {
+    engine.intern(Type::GenericParameter(GenericParameterID::new(
+        owner,
+        ID::<GenericParameter>::new(index),
+    )))
+}
+
+fn lifetime_parameter(index: u64, engine: &TrackedEngine) -> Interned<Type> {
+    generic(LIFETIME_SYMBOL_ID, index, engine)
+}
+
+fn type_parameter(index: u64, engine: &TrackedEngine) -> Interned<Type> {
+    generic(TYPE_SYMBOL_ID, index, engine)
+}
+
+fn instance_parameter(index: u64, engine: &TrackedEngine) -> Interned<Type> {
+    generic(INSTANCE_SYMBOL_ID, index, engine)
+}
+
+fn reference(
+    lifetime: Interned<Type>,
+    pointee: Interned<Type>,
+    engine: &TrackedEngine,
+) -> Interned<Type> {
+    application(
+        Constructor::Reference(Reference::new(Mutability::Immutable)),
+        [lifetime, pointee],
+        engine,
+    )
+}
+
+fn tuple(
+    arguments: impl IntoIterator<Item = Interned<Type>>,
+    engine: &TrackedEngine,
+) -> Interned<Type> {
+    application(
+        Constructor::Tuple(Tuple::new(engine.intern_unsized(Vec::new()))),
+        arguments,
+        engine,
+    )
+}
+
+fn symbolic(
+    arguments: impl IntoIterator<Item = Interned<Type>>,
+    engine: &TrackedEngine,
+) -> Interned<Type> {
+    application(
+        Constructor::Symbolic(Symbolic::new(INSTANCE_SYMBOL_ID)),
+        arguments,
+        engine,
+    )
+}
+
+fn anonymous_instance(engine: &TrackedEngine) -> Interned<Type> {
+    application(
+        Constructor::AnonymousTraitInstance(AnonymousTraitInstance::new(
+            TRAIT_ID,
+        )),
+        [],
+        engine,
+    )
+}
+
+fn associated(
+    instance: Interned<Type>,
+    arguments: impl IntoIterator<Item = Interned<Type>>,
+    engine: &TrackedEngine,
+) -> Interned<Type> {
+    application(
+        Constructor::InstanceAssociated(InstanceAssociated::new(ASSOCIATED_ID)),
+        std::iter::once(instance).chain(arguments),
+        engine,
+    )
+}
+
+fn function_pointer(
+    bound_lifetimes: usize,
+    arguments: impl IntoIterator<Item = Interned<Type>>,
+    engine: &TrackedEngine,
+) -> Interned<Type> {
+    application(
+        Constructor::FunctionPointer(FunctionPointer::new(Binder::new(
+            engine.intern_unsized(vec![TyKind::Lifetime; bound_lifetimes]),
+        ))),
+        arguments,
+        engine,
+    )
+}
+
+fn bound_lifetime(index: usize, engine: &TrackedEngine) -> Interned<Type> {
+    engine.intern(Type::BoundVariable(BoundVariable::new(0, index)))
+}
+
+fn outlives(lesser: Interned<Type>, greater: Interned<Type>) -> Predicate {
+    Predicate::Outlives(Outlives::new(lesser, greater))
+}
+
+fn equality(
+    left: Interned<Type>,
+    right: Interned<Type>,
+    engine: &TrackedEngine,
+) -> Predicate {
+    Predicate::Equality(Equality::new(
+        Binder::new(engine.intern_unsized(Vec::new())),
+        left,
+        right,
+    ))
+}
+
+async fn prove(
+    premise: &Premise,
+    lesser: Interned<Type>,
+    greater: Interned<Type>,
+    engine: &TrackedEngine,
+) -> bool {
+    Solver::new(premise, engine)
+        .outlives(&Outlives::new(lesser, greater))
+        .await
+        .unwrap()
+}
+
+// input: 'erased: 'erased, 'static: 'erased, 'erased: 'static
+// premise: {}
+// output: true, true, false
+#[tokio::test]
+async fn lifetime_reflexivity_static_and_erased() {
+    let engine = create_engine().await;
+    let erased = lifetime(Lifetime::Erased, &engine);
+    let static_lifetime = lifetime(Lifetime::Static, &engine);
+
+    assert!(
+        prove(&Premise::default(), erased.clone(), erased.clone(), &engine,)
+            .await
+    );
+    assert!(
+        prove(&Premise::default(), static_lifetime, erased.clone(), &engine,)
+            .await
+    );
+    assert!(
+        !prove(
+            &Premise::default(),
+            erased,
+            lifetime(Lifetime::Static, &engine),
+            &engine,
+        )
+        .await
+    );
+}
+
+// input: 'a: 'c, 'a: 'd
+// premise: 'a: 'b, 'b: 'c, 'c: 'b
+// output: true, false
+#[tokio::test]
+async fn lifetime_premises_are_transitive_and_cycles_terminate() {
+    let engine = create_engine().await;
+    let a = lifetime_parameter(0, &engine);
+    let b = lifetime_parameter(1, &engine);
+    let c = lifetime_parameter(2, &engine);
+    let d = lifetime_parameter(3, &engine);
+    let mut premise = Premise::default();
+    premise.insert(outlives(a.clone(), b.clone()));
+    premise.insert(outlives(b.clone(), c.clone()));
+    premise.insert(outlives(c.clone(), b));
+
+    assert!(prove(&premise, a.clone(), c, &engine).await);
+    assert!(!prove(&premise, a, d, &engine).await);
+}
+
+// input: 'b: 'bound
+// premise: 'a: 'bound
+// output: false
+#[tokio::test]
+async fn lifetime_premise_matching_requires_same_lesser() {
+    let engine = create_engine().await;
+    let a = lifetime_parameter(0, &engine);
+    let b = lifetime_parameter(1, &engine);
+    let bound = lifetime_parameter(2, &engine);
+    let mut premise = Premise::default();
+    premise.insert(outlives(a, bound.clone()));
+
+    assert!(!prove(&premise, b, bound, &engine).await);
+}
+
+// input: (&'a T,): 'bound, bool: 'bound
+// premise: 'a: 'bound, then T: 'bound
+// output: false before T: 'bound, then true; bool is always true
+#[tokio::test]
+async fn ordinary_terms_require_every_component() {
+    let engine = create_engine().await;
+    let a = lifetime_parameter(0, &engine);
+    let ty = type_parameter(0, &engine);
+    let bound = lifetime_parameter(1, &engine);
+    let subject = tuple([reference(a.clone(), ty.clone(), &engine)], &engine);
+    let mut premise = Premise::default();
+    premise.insert(outlives(a, bound.clone()));
+
+    assert!(!prove(&premise, subject.clone(), bound.clone(), &engine).await);
+
+    premise.insert(outlives(ty, bound.clone()));
+    assert!(prove(&premise, subject, bound, &engine).await);
+    assert!(
+        prove(
+            &Premise::default(),
+            primitive(Primitive::Bool, &engine),
+            lifetime_parameter(2, &engine),
+            &engine,
+        )
+        .await
+    );
+}
+
+// input: Instance[T]: 'bound
+// premise: {}, then T: 'bound
+// output: false, then true
+#[tokio::test]
+async fn symbolic_instance_arguments_are_components() {
+    let engine = create_engine().await;
+    let argument = type_parameter(0, &engine);
+    let bound = lifetime_parameter(0, &engine);
+    let subject = symbolic([argument.clone()], &engine);
+    let mut premise = Premise::default();
+
+    assert!(!prove(&premise, subject.clone(), bound.clone(), &engine).await);
+    premise.insert(outlives(argument, bound.clone()));
+    assert!(prove(&premise, subject, bound, &engine).await);
+}
+
+// input: for<'a> fn(&'a bool, T): 'bound
+// premise: {}, then T: 'bound
+// output: false, then true
+#[tokio::test]
+async fn function_pointer_ignores_bound_lifetimes_but_keeps_free_components() {
+    let engine = create_engine().await;
+    let free = type_parameter(0, &engine);
+    let bound = lifetime_parameter(0, &engine);
+    let subject = function_pointer(
+        1,
+        [
+            reference(
+                bound_lifetime(0, &engine),
+                primitive(Primitive::Bool, &engine),
+                &engine,
+            ),
+            free.clone(),
+        ],
+        &engine,
+    );
+    let mut premise = Premise::default();
+
+    assert!(!prove(&premise, subject.clone(), bound.clone(), &engine).await);
+    premise.insert(outlives(free, bound.clone()));
+    assert!(prove(&premise, subject, bound, &engine).await);
+}
+
+// input: ?T: 'static, !T: 'static
+// premise: {}
+// output: false, false
+#[tokio::test]
+async fn inference_and_skolem_variables_are_rigid_components() {
+    let engine = create_engine().await;
+    let premise = Premise::default();
+    let mut solver = Solver::new(&premise, &engine);
+    let inference = solver.fresh_inference_variable(TyKind::Type);
+    let skolem = solver.fresh_skolem_variable(TyKind::Type);
+    let bound = lifetime(Lifetime::Static, &engine);
+
+    assert!(
+        !solver
+            .outlives(&Outlives::new(
+                engine.intern(Type::InferenceVariable(inference)),
+                bound.clone(),
+            ))
+            .await
+            .unwrap()
+    );
+    assert!(
+        !solver
+            .outlives(&Outlives::new(
+                engine.intern(Type::SkolemizedVariable(skolem)),
+                bound,
+            ))
+            .await
+            .unwrap()
+    );
+}
+
+// input: 'a: 'bound, T: 'bound
+// premise: (&'a T,): 'bound
+// output: true, true
+#[tokio::test]
+async fn composite_premise_entails_each_component() {
+    let engine = create_engine().await;
+    let a = lifetime_parameter(0, &engine);
+    let ty = type_parameter(0, &engine);
+    let bound = lifetime_parameter(1, &engine);
+    let mut premise = Premise::default();
+    premise.insert(outlives(
+        tuple([reference(a.clone(), ty.clone(), &engine)], &engine),
+        bound.clone(),
+    ));
+
+    assert!(prove(&premise, a, bound.clone(), &engine).await);
+    assert!(prove(&premise, ty, bound, &engine).await);
+}
+
+// input: I::Assoc['a]: 'bound, I: 'bound, 'a: 'bound
+// premise: I::Assoc['a]: 'bound
+// output: true, false, false
+#[tokio::test]
+async fn associated_premise_is_atomic() {
+    let engine = create_engine().await;
+    let instance = instance_parameter(0, &engine);
+    let argument = lifetime_parameter(0, &engine);
+    let bound = lifetime_parameter(1, &engine);
+    let associated = associated(instance.clone(), [argument.clone()], &engine);
+    let mut premise = Premise::default();
+    premise.insert(outlives(associated.clone(), bound.clone()));
+
+    assert!(prove(&premise, associated, bound.clone(), &engine).await);
+    assert!(!prove(&premise, instance, bound.clone(), &engine).await);
+    assert!(!prove(&premise, argument, bound, &engine).await);
+}
+
+// input: I::Assoc['a]: 'bound, I: 'bound, 'a: 'bound
+// premise: (I::Assoc['a],): 'bound
+// output: true, false, false
+#[tokio::test]
+async fn nested_associated_component_remains_atomic() {
+    let engine = create_engine().await;
+    let instance = instance_parameter(0, &engine);
+    let argument = lifetime_parameter(0, &engine);
+    let bound = lifetime_parameter(1, &engine);
+    let associated = associated(instance.clone(), [argument.clone()], &engine);
+    let mut premise = Premise::default();
+    premise
+        .insert(outlives(tuple([associated.clone()], &engine), bound.clone()));
+
+    assert!(prove(&premise, associated, bound.clone(), &engine).await);
+    assert!(!prove(&premise, instance, bound.clone(), &engine).await);
+    assert!(!prove(&premise, argument, bound, &engine).await);
+}
+
+// input: I::Assoc['a]: 'bound
+// premise: I: 'bound, then 'a: 'bound
+// output: false, then true
+#[tokio::test]
+async fn associated_goal_falls_back_to_argument_components() {
+    let engine = create_engine().await;
+    let instance = instance_parameter(0, &engine);
+    let argument = lifetime_parameter(0, &engine);
+    let bound = lifetime_parameter(1, &engine);
+    let associated = associated(instance.clone(), [argument.clone()], &engine);
+    let mut premise = Premise::default();
+    premise.insert(outlives(instance, bound.clone()));
+
+    assert!(!prove(&premise, associated.clone(), bound.clone(), &engine).await);
+    premise.insert(outlives(argument, bound.clone()));
+    assert!(prove(&premise, associated, bound, &engine).await);
+}
+
+// input: I::Assoc: 'bound
+// premise: I::Assoc = bool
+// output: true
+#[tokio::test]
+async fn associated_goal_can_be_reduced_by_equality() {
+    let engine = create_engine().await;
+    let associated = associated(anonymous_instance(&engine), [], &engine);
+    let bound = lifetime_parameter(0, &engine);
+    let mut premise = Premise::default();
+    premise.insert(equality(
+        associated.clone(),
+        primitive(Primitive::Bool, &engine),
+        &engine,
+    ));
+
+    assert!(prove(&premise, associated, bound, &engine).await);
+}
+
+// input: I::Assoc['b]: 'bound
+// premise: I::Assoc['a]: 'bound, then 'a: 'b and 'b: 'a
+// output: false, then true
+#[tokio::test]
+async fn premise_matching_checks_lifetime_equality_constraints() {
+    let engine = create_engine().await;
+    let a = lifetime_parameter(0, &engine);
+    let b = lifetime_parameter(1, &engine);
+    let bound = lifetime_parameter(2, &engine);
+    let instance = anonymous_instance(&engine);
+    let premise_associated = associated(instance.clone(), [a.clone()], &engine);
+    let goal_associated = associated(instance, [b.clone()], &engine);
+    let mut premise = Premise::default();
+    premise.insert(outlives(premise_associated, bound.clone()));
+
+    assert!(
+        !prove(&premise, goal_associated.clone(), bound.clone(), &engine).await
+    );
+
+    premise.insert(outlives(a.clone(), b.clone()));
+    premise.insert(outlives(b, a));
+    assert!(prove(&premise, goal_associated, bound, &engine).await);
+}
+
+// input: bool: 'bound
+// premise: ?T: 'bound
+// output: panic because outlives premises may not contain inference variables
+#[tokio::test]
+#[should_panic(
+    expected = "outlives premises must not contain inference variables"
+)]
+async fn premise_matching_rejects_inference_variable_substitution() {
+    let engine = create_engine().await;
+    let mut premise = Premise::default();
+    let empty_premise = Premise::default();
+    let mut variable_solver = Solver::new(&empty_premise, &engine);
+    let inference = variable_solver.fresh_inference_variable(TyKind::Type);
+    let inference = engine.intern(Type::InferenceVariable(inference));
+    let bound = lifetime_parameter(0, &engine);
+    premise.insert(outlives(inference, bound.clone()));
+
+    let _ =
+        prove(&premise, primitive(Primitive::Bool, &engine), bound, &engine)
+            .await;
+}

--- a/compiler/semantic/solver/src/solver.rs
+++ b/compiler/semantic/solver/src/solver.rs
@@ -148,6 +148,10 @@ impl Agree for Constraints {
     fn agree(&self, other: &Self) -> bool { self == other }
 }
 
+impl Agree for bool {
+    fn agree(&self, other: &Self) -> bool { self == other }
+}
+
 impl Agree for Substitution {
     fn agree(&self, other: &Self) -> bool { self == other }
 }

--- a/compiler/semantic/type/src/generic_parameters.rs
+++ b/compiler/semantic/type/src/generic_parameters.rs
@@ -51,6 +51,15 @@ pub struct GenericParameter {
 
 impl GenericParameter {
     #[must_use]
+    pub const fn new(
+        name: Interned<str>,
+        span: Option<RelativeSpan>,
+        kind: GenericParameterKind,
+    ) -> Self {
+        Self { name, span, kind }
+    }
+
+    #[must_use]
     pub const fn kind(&self) -> TyKind {
         match &self.kind {
             GenericParameterKind::Lifetime => TyKind::Lifetime,
@@ -74,6 +83,11 @@ impl GenericParameter {
 )]
 pub struct InstanceParameterKind {
     trait_ref: Option<Symbol>,
+}
+
+impl InstanceParameterKind {
+    #[must_use]
+    pub const fn new(trait_ref: Option<Symbol>) -> Self { Self { trait_ref } }
 }
 
 #[derive(
@@ -110,6 +124,17 @@ pub struct GenericParameters {
 }
 
 impl GenericParameters {
+    #[must_use]
+    pub fn new(parameters: impl IntoIterator<Item = GenericParameter>) -> Self {
+        let mut arena = OrderedArena::new();
+
+        for parameter in parameters {
+            arena.insert(parameter);
+        }
+
+        Self { parameters: arena }
+    }
+
     #[must_use]
     pub fn len(&self) -> usize { self.parameters.len() }
 

--- a/compiler/semantic/type/src/predicate.rs
+++ b/compiler/semantic/type/src/predicate.rs
@@ -92,10 +92,10 @@ impl Substitutable for Equality {
     Decode,
 )]
 pub struct Outlives {
-    /// Can either has a kind of lifetime or a kind of type.
+    /// Must have lifetime, type, or instance kind.
     lesser: Interned<Type>,
 
-    /// Must always has a kind of lifetime.
+    /// Must have lifetime kind.
     greater: Interned<Type>,
 }
 

--- a/compiler/semantic/type/src/type/constructor.rs
+++ b/compiler/semantic/type/src/type/constructor.rs
@@ -150,6 +150,11 @@ pub struct Symbolic {
 
 impl Symbolic {
     #[must_use]
+    pub const fn new(symbolic_id: GlobalSymbolID) -> Self {
+        Self { symbolic_id }
+    }
+
+    #[must_use]
     pub const fn symbol_id(&self) -> GlobalSymbolID { self.symbolic_id }
 }
 
@@ -221,6 +226,11 @@ pub struct InstanceAssociated {
 
 impl InstanceAssociated {
     #[must_use]
+    pub const fn new(trait_associated_id: GlobalSymbolID) -> Self {
+        Self { trait_associated_id }
+    }
+
+    #[must_use]
     pub const fn trait_associated_id(&self) -> GlobalSymbolID {
         self.trait_associated_id
     }
@@ -263,6 +273,9 @@ pub struct AnonymousTraitInstance {
 }
 
 impl AnonymousTraitInstance {
+    #[must_use]
+    pub const fn new(trait_id: GlobalSymbolID) -> Self { Self { trait_id } }
+
     #[must_use]
     pub const fn trait_id(&self) -> GlobalSymbolID { self.trait_id }
 }


### PR DESCRIPTION
## Summary

- add symbolic `Outlives` solving to `pernixc_solver`
- dispatch homogeneous terms by `TyKind` for lifetime, type, and instance behavior
- support premise transitivity, subtype-based type premises, emitted lifetime constraints, equality reduction, and cyclic-query handling
- ignore function-pointer late-bound lifetime components while continuing to check free components, matching rustc behavior

## Why

The new constraint/predicate solver did not yet implement the symbolic outlives logic available in the deprecated type-system solver. This adds that capability using the new homogeneous type representation and existing solver query infrastructure.

## Impact

Callers can now use `Solver::outlives` to prove lifetime and type outlives predicates without depending on the legacy type-system crate. Higher-ranked function-pointer binders do not create external outlives obligations.

## Validation

- `cargo test -p pernixc_solver` (38 passed)
- `cargo clippy -p pernixc_solver --all-targets -- -D warnings`
- `cargo +nightly fmt --all --check`
