### PR TITLE
Refine type constructor reduction and solver tests

### DIFF
--- a/compiler/base/qbice/src/lib.rs
+++ b/compiler/base/qbice/src/lib.rs
@@ -8,6 +8,7 @@ use linkme::distributed_slice;
 use qbice::{
     Identifiable, StableHash,
     program::Registration,
+    serialize::Plugin,
     stable_hash::{SeededStableHasherBuilder, Sip128Hasher},
     storage::{
         self,
@@ -59,6 +60,23 @@ pub type TrackedEngine = qbice::TrackedEngine<Config>;
 /// Type alias for the [`qbice::InputSession`] with configuration set to
 /// [`Config`].
 pub type InputSession = qbice::InputSession<Config>;
+
+/// Creates a tracked engine with an in-memory database and no registered
+/// executors.
+#[must_use]
+pub async fn create_minimal_engine() -> TrackedEngine {
+    Arc::new(
+        Engine::new_with(
+            Plugin::default(),
+            InMemoryFactory,
+            SeededStableHasherBuilder::new(0),
+        )
+        .await
+        .unwrap(),
+    )
+    .tracked()
+    .await
+}
 
 /// Distributed slice for registering all the executors required for Pernix
 /// compiler.

--- a/compiler/semantic/solver/src/outlives/test.rs
+++ b/compiler/semantic/solver/src/outlives/test.rs
@@ -13,11 +13,7 @@ use pernixc_type::{
     r#type::{
         Type,
         bound::{Binder, BoundVariable},
-        constructor::{
-            AnonymousTraitInstance, Application, Constructor, FunctionPointer,
-            InstanceAssociated, Lifetime, Mutability, Primitive, Reference,
-            Symbolic, Tuple,
-        },
+        constructor::{Lifetime, Primitive},
         kind::TyKind,
     },
 };
@@ -104,34 +100,15 @@ async fn create_engine() -> TrackedEngine {
     Arc::new(engine).tracked().await
 }
 
-fn application(
-    constructor: Constructor,
-    arguments: impl IntoIterator<Item = Interned<Type>>,
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    engine.intern(Type::Application(Application::new(
-        constructor,
-        engine.intern_unsized(arguments.into_iter().collect::<Vec<_>>()),
-    )))
-}
-
-fn primitive(primitive: Primitive, engine: &TrackedEngine) -> Interned<Type> {
-    application(Constructor::Primitive(primitive), [], engine)
-}
-
-fn lifetime(lifetime: Lifetime, engine: &TrackedEngine) -> Interned<Type> {
-    application(Constructor::Lifetime(lifetime), [], engine)
-}
-
 fn generic(
     owner: GlobalSymbolID,
     index: u64,
     engine: &TrackedEngine,
 ) -> Interned<Type> {
-    engine.intern(Type::GenericParameter(GenericParameterID::new(
-        owner,
-        ID::<GenericParameter>::new(index),
-    )))
+    Type::new_generic_parameter(
+        GenericParameterID::new(owner, ID::<GenericParameter>::new(index)),
+        engine,
+    )
 }
 
 fn lifetime_parameter(index: u64, engine: &TrackedEngine) -> Interned<Type> {
@@ -144,80 +121,6 @@ fn type_parameter(index: u64, engine: &TrackedEngine) -> Interned<Type> {
 
 fn instance_parameter(index: u64, engine: &TrackedEngine) -> Interned<Type> {
     generic(INSTANCE_SYMBOL_ID, index, engine)
-}
-
-fn reference(
-    lifetime: Interned<Type>,
-    pointee: Interned<Type>,
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    application(
-        Constructor::Reference(Reference::new(Mutability::Immutable)),
-        [lifetime, pointee],
-        engine,
-    )
-}
-
-fn tuple(
-    arguments: impl IntoIterator<Item = Interned<Type>>,
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    application(
-        Constructor::Tuple(Tuple::new(engine.intern_unsized(Vec::new()))),
-        arguments,
-        engine,
-    )
-}
-
-fn symbolic(
-    arguments: impl IntoIterator<Item = Interned<Type>>,
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    application(
-        Constructor::Symbolic(Symbolic::new(INSTANCE_SYMBOL_ID)),
-        arguments,
-        engine,
-    )
-}
-
-fn anonymous_instance(engine: &TrackedEngine) -> Interned<Type> {
-    application(
-        Constructor::AnonymousTraitInstance(AnonymousTraitInstance::new(
-            TRAIT_ID,
-        )),
-        [],
-        engine,
-    )
-}
-
-fn associated(
-    instance: Interned<Type>,
-    arguments: impl IntoIterator<Item = Interned<Type>>,
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    application(
-        Constructor::InstanceAssociated(InstanceAssociated::new(ASSOCIATED_ID)),
-        std::iter::once(instance).chain(arguments),
-        engine,
-    )
-}
-
-fn function_pointer(
-    bound_lifetimes: usize,
-    arguments: impl IntoIterator<Item = Interned<Type>>,
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    application(
-        Constructor::FunctionPointer(FunctionPointer::new(Binder::new(
-            engine.intern_unsized(vec![TyKind::Lifetime; bound_lifetimes]),
-        ))),
-        arguments,
-        engine,
-    )
-}
-
-fn bound_lifetime(index: usize, engine: &TrackedEngine) -> Interned<Type> {
-    engine.intern(Type::BoundVariable(BoundVariable::new(0, index)))
 }
 
 fn outlives(lesser: Interned<Type>, greater: Interned<Type>) -> Predicate {
@@ -254,8 +157,8 @@ async fn prove(
 #[tokio::test]
 async fn lifetime_reflexivity_static_and_erased() {
     let engine = create_engine().await;
-    let erased = lifetime(Lifetime::Erased, &engine);
-    let static_lifetime = lifetime(Lifetime::Static, &engine);
+    let erased = Type::new_lifetime(Lifetime::Erased, &engine);
+    let static_lifetime = Type::new_lifetime(Lifetime::Static, &engine);
 
     assert!(
         prove(&Premise::default(), erased.clone(), erased.clone(), &engine,)
@@ -269,7 +172,7 @@ async fn lifetime_reflexivity_static_and_erased() {
         !prove(
             &Premise::default(),
             erased,
-            lifetime(Lifetime::Static, &engine),
+            Type::new_lifetime(Lifetime::Static, &engine),
             &engine,
         )
         .await
@@ -319,7 +222,10 @@ async fn ordinary_terms_require_every_component() {
     let a = lifetime_parameter(0, &engine);
     let ty = type_parameter(0, &engine);
     let bound = lifetime_parameter(1, &engine);
-    let subject = tuple([reference(a.clone(), ty.clone(), &engine)], &engine);
+    let subject = Type::new_tuple(
+        [Type::new_immutable_reference(a.clone(), ty.clone(), &engine)],
+        &engine,
+    );
     let mut premise = Premise::default();
     premise.insert(outlives(a, bound.clone()));
 
@@ -330,7 +236,7 @@ async fn ordinary_terms_require_every_component() {
     assert!(
         prove(
             &Premise::default(),
-            primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
             lifetime_parameter(2, &engine),
             &engine,
         )
@@ -346,7 +252,8 @@ async fn symbolic_instance_arguments_are_components() {
     let engine = create_engine().await;
     let argument = type_parameter(0, &engine);
     let bound = lifetime_parameter(0, &engine);
-    let subject = symbolic([argument.clone()], &engine);
+    let subject =
+        Type::new_symbolic(INSTANCE_SYMBOL_ID, [argument.clone()], &engine);
     let mut premise = Premise::default();
 
     assert!(!prove(&premise, subject.clone(), bound.clone(), &engine).await);
@@ -362,16 +269,14 @@ async fn function_pointer_ignores_bound_lifetimes_but_keeps_free_components() {
     let engine = create_engine().await;
     let free = type_parameter(0, &engine);
     let bound = lifetime_parameter(0, &engine);
-    let subject = function_pointer(
+    let subject = Type::new_function_pointer_with_higher_ranked_lifetimes(
         1,
-        [
-            reference(
-                bound_lifetime(0, &engine),
-                primitive(Primitive::Bool, &engine),
-                &engine,
-            ),
-            free.clone(),
-        ],
+        [Type::new_immutable_reference(
+            Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
+            &engine,
+        )],
+        free.clone(),
         &engine,
     );
     let mut premise = Premise::default();
@@ -391,12 +296,12 @@ async fn inference_and_skolem_variables_are_rigid_components() {
     let mut solver = Solver::new(&premise, &engine);
     let inference = solver.fresh_inference_variable(TyKind::Type);
     let skolem = solver.fresh_skolem_variable(TyKind::Type);
-    let bound = lifetime(Lifetime::Static, &engine);
+    let bound = Type::new_lifetime(Lifetime::Static, &engine);
 
     assert!(
         !solver
             .outlives(&Outlives::new(
-                engine.intern(Type::InferenceVariable(inference)),
+                Type::new_inference_variable(inference, &engine),
                 bound.clone(),
             ))
             .await
@@ -405,7 +310,7 @@ async fn inference_and_skolem_variables_are_rigid_components() {
     assert!(
         !solver
             .outlives(&Outlives::new(
-                engine.intern(Type::SkolemizedVariable(skolem)),
+                Type::new_skolemized_variable(skolem, &engine),
                 bound,
             ))
             .await
@@ -424,7 +329,10 @@ async fn composite_premise_entails_each_component() {
     let bound = lifetime_parameter(1, &engine);
     let mut premise = Premise::default();
     premise.insert(outlives(
-        tuple([reference(a.clone(), ty.clone(), &engine)], &engine),
+        Type::new_tuple(
+            [Type::new_immutable_reference(a.clone(), ty.clone(), &engine)],
+            &engine,
+        ),
         bound.clone(),
     ));
 
@@ -441,7 +349,12 @@ async fn associated_premise_is_atomic() {
     let instance = instance_parameter(0, &engine);
     let argument = lifetime_parameter(0, &engine);
     let bound = lifetime_parameter(1, &engine);
-    let associated = associated(instance.clone(), [argument.clone()], &engine);
+    let associated = Type::new_instance_associated(
+        ASSOCIATED_ID,
+        instance.clone(),
+        [argument.clone()],
+        &engine,
+    );
     let mut premise = Premise::default();
     premise.insert(outlives(associated.clone(), bound.clone()));
 
@@ -459,10 +372,17 @@ async fn nested_associated_component_remains_atomic() {
     let instance = instance_parameter(0, &engine);
     let argument = lifetime_parameter(0, &engine);
     let bound = lifetime_parameter(1, &engine);
-    let associated = associated(instance.clone(), [argument.clone()], &engine);
+    let associated = Type::new_instance_associated(
+        ASSOCIATED_ID,
+        instance.clone(),
+        [argument.clone()],
+        &engine,
+    );
     let mut premise = Premise::default();
-    premise
-        .insert(outlives(tuple([associated.clone()], &engine), bound.clone()));
+    premise.insert(outlives(
+        Type::new_tuple([associated.clone()], &engine),
+        bound.clone(),
+    ));
 
     assert!(prove(&premise, associated, bound.clone(), &engine).await);
     assert!(!prove(&premise, instance, bound.clone(), &engine).await);
@@ -478,7 +398,12 @@ async fn associated_goal_falls_back_to_argument_components() {
     let instance = instance_parameter(0, &engine);
     let argument = lifetime_parameter(0, &engine);
     let bound = lifetime_parameter(1, &engine);
-    let associated = associated(instance.clone(), [argument.clone()], &engine);
+    let associated = Type::new_instance_associated(
+        ASSOCIATED_ID,
+        instance.clone(),
+        [argument.clone()],
+        &engine,
+    );
     let mut premise = Premise::default();
     premise.insert(outlives(instance, bound.clone()));
 
@@ -493,12 +418,17 @@ async fn associated_goal_falls_back_to_argument_components() {
 #[tokio::test]
 async fn associated_goal_can_be_reduced_by_equality() {
     let engine = create_engine().await;
-    let associated = associated(anonymous_instance(&engine), [], &engine);
+    let associated = Type::new_instance_associated(
+        ASSOCIATED_ID,
+        Type::new_anonymous_trait_instance(TRAIT_ID, &engine),
+        [],
+        &engine,
+    );
     let bound = lifetime_parameter(0, &engine);
     let mut premise = Premise::default();
     premise.insert(equality(
         associated.clone(),
-        primitive(Primitive::Bool, &engine),
+        Type::new_primitive(Primitive::Bool, &engine),
         &engine,
     ));
 
@@ -514,9 +444,19 @@ async fn premise_matching_checks_lifetime_equality_constraints() {
     let a = lifetime_parameter(0, &engine);
     let b = lifetime_parameter(1, &engine);
     let bound = lifetime_parameter(2, &engine);
-    let instance = anonymous_instance(&engine);
-    let premise_associated = associated(instance.clone(), [a.clone()], &engine);
-    let goal_associated = associated(instance, [b.clone()], &engine);
+    let instance = Type::new_anonymous_trait_instance(TRAIT_ID, &engine);
+    let premise_associated = Type::new_instance_associated(
+        ASSOCIATED_ID,
+        instance.clone(),
+        [a.clone()],
+        &engine,
+    );
+    let goal_associated = Type::new_instance_associated(
+        ASSOCIATED_ID,
+        instance,
+        [b.clone()],
+        &engine,
+    );
     let mut premise = Premise::default();
     premise.insert(outlives(premise_associated, bound.clone()));
 
@@ -542,11 +482,15 @@ async fn premise_matching_rejects_inference_variable_substitution() {
     let empty_premise = Premise::default();
     let mut variable_solver = Solver::new(&empty_premise, &engine);
     let inference = variable_solver.fresh_inference_variable(TyKind::Type);
-    let inference = engine.intern(Type::InferenceVariable(inference));
+    let inference = Type::new_inference_variable(inference, &engine);
     let bound = lifetime_parameter(0, &engine);
     premise.insert(outlives(inference, bound.clone()));
 
-    let _ =
-        prove(&premise, primitive(Primitive::Bool, &engine), bound, &engine)
-            .await;
+    let _ = prove(
+        &premise,
+        Type::new_primitive(Primitive::Bool, &engine),
+        bound,
+        &engine,
+    )
+    .await;
 }

--- a/compiler/semantic/solver/src/reduction/test.rs
+++ b/compiler/semantic/solver/src/reduction/test.rs
@@ -1,75 +1,23 @@
-use std::sync::Arc;
-
-use pernixc_qbice::{Engine, InMemoryFactory, TrackedEngine};
+use pernixc_qbice::{
+    TrackedEngine, create_minimal_engine as create_test_engine,
+};
 use pernixc_type::{
     predicate::{Equality, Predicate},
     r#type::{
         Type,
         bound::{Binder, BoundVariable},
-        constructor::{
-            Application, Constructor, Mutability, Primitive, Reference, Tuple,
-        },
+        constructor::Primitive,
         kind::TyKind,
         skolem::SkolemizedVariable,
     },
 };
-use qbice::{
-    serialize::Plugin, stable_hash::SeededStableHasherBuilder,
-    storage::intern::Interned,
-};
+use qbice::storage::intern::Interned;
 
 use crate::{
     constraints::Constraints,
     premise::Premise,
     solver::{OverflowError, Solver},
 };
-
-async fn create_test_engine() -> TrackedEngine {
-    let engine = Engine::new_with(
-        Plugin::default(),
-        InMemoryFactory,
-        SeededStableHasherBuilder::new(0),
-    )
-    .await
-    .unwrap();
-
-    Arc::new(engine).tracked().await
-}
-
-fn primitive(primitive: Primitive, engine: &TrackedEngine) -> Interned<Type> {
-    engine.intern(Type::Application(Application::new(
-        Constructor::Primitive(primitive),
-        engine.intern_unsized(Vec::<Interned<Type>>::new()),
-    )))
-}
-
-fn reference(
-    lifetime: Interned<Type>,
-    pointee: Interned<Type>,
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    engine.intern(Type::Application(Application::new(
-        Constructor::Reference(Reference::new(Mutability::Immutable)),
-        engine.intern_unsized(vec![lifetime, pointee]),
-    )))
-}
-
-fn skolem_lifetime(id: u64, engine: &TrackedEngine) -> Interned<Type> {
-    engine.intern(Type::SkolemizedVariable(SkolemizedVariable::new(id)))
-}
-
-fn tuple(
-    arguments: &[Interned<Type>],
-    unpacked_positions: &[usize],
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    engine.intern(Type::Application(Application::new(
-        Constructor::Tuple(Tuple::new(
-            engine.intern_unsized(unpacked_positions.to_vec()),
-        )),
-        engine.intern_unsized(arguments.to_vec()),
-    )))
-}
 
 fn equality(
     left: Interned<Type>,
@@ -90,14 +38,6 @@ fn higher_ranked_equality(
         left,
         right,
     ))
-}
-
-fn bound_type(index: usize, engine: &TrackedEngine) -> Interned<Type> {
-    engine.intern(Type::BoundVariable(BoundVariable::new(0, index)))
-}
-
-fn bound_lifetime(index: usize, engine: &TrackedEngine) -> Interned<Type> {
-    bound_type(index, engine)
 }
 
 async fn reduce_type(
@@ -130,24 +70,23 @@ async fn reduce_type_with_lifetime_skolems(
 async fn reduce_type_recursively_reduces_nested_applications() {
     let engine = create_test_engine().await;
 
-    let inner = tuple(
-        &[
-            primitive(Primitive::Int32, &engine),
-            tuple(
-                &[
-                    primitive(Primitive::Bool, &engine),
-                    primitive(Primitive::Float32, &engine),
+    let inner = Type::new_tuple_with_unpack(
+        [
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_tuple(
+                [
+                    Type::new_primitive(Primitive::Bool, &engine),
+                    Type::new_primitive(Primitive::Float32, &engine),
                 ],
-                &[],
                 &engine,
             ),
-            primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
         ],
-        &[1],
+        [1],
         &engine,
     );
 
-    let subject = tuple(&[inner], &[0], &engine);
+    let subject = Type::new_tuple_with_unpack([inner], [0], &engine);
 
     let (reduced, constraints) =
         reduce_type(subject, &Premise::default(), &engine)
@@ -157,15 +96,14 @@ async fn reduce_type_recursively_reduces_nested_applications() {
 
     assert_eq!(
         reduced,
-        tuple(
-            &[
-                primitive(Primitive::Int32, &engine),
-                primitive(Primitive::Bool, &engine),
-                primitive(Primitive::Float32, &engine),
-                primitive(Primitive::Uint64, &engine),
+        Type::new_tuple(
+            [
+                Type::new_primitive(Primitive::Int32, &engine),
+                Type::new_primitive(Primitive::Bool, &engine),
+                Type::new_primitive(Primitive::Float32, &engine),
+                Type::new_primitive(Primitive::Uint64, &engine),
             ],
-            &[],
-            &engine,
+            &engine
         )
     );
     assert_eq!(constraints, Constraints::default());
@@ -180,19 +118,19 @@ async fn reduce_type_emits_lifetime_constraints_from_equality_match() {
     let mut premise = Premise::default();
 
     premise.insert(equality(
-        reference(
-            skolem_lifetime(0, &engine),
-            primitive(Primitive::Bool, &engine),
+        Type::new_immutable_reference(
+            Type::new_skolemized_variable(SkolemizedVariable::new(0), &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
             &engine,
         ),
-        primitive(Primitive::Bool, &engine),
+        Type::new_primitive(Primitive::Bool, &engine),
         &engine,
     ));
 
     let (reduced, constraints) = reduce_type_with_lifetime_skolems(
-        reference(
-            skolem_lifetime(1, &engine),
-            primitive(Primitive::Bool, &engine),
+        Type::new_immutable_reference(
+            Type::new_skolemized_variable(SkolemizedVariable::new(1), &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
             &engine,
         ),
         &premise,
@@ -203,12 +141,12 @@ async fn reduce_type_emits_lifetime_constraints_from_equality_match() {
     .unwrap()
     .unwrap();
 
-    assert_eq!(reduced, primitive(Primitive::Bool, &engine));
+    assert_eq!(reduced, Type::new_primitive(Primitive::Bool, &engine));
     assert_eq!(
         constraints,
         Constraints::lifetimes_eq(
-            skolem_lifetime(0, &engine),
-            skolem_lifetime(1, &engine),
+            Type::new_skolemized_variable(SkolemizedVariable::new(0), &engine),
+            Type::new_skolemized_variable(SkolemizedVariable::new(1), &engine),
         )
     );
 }
@@ -223,15 +161,19 @@ async fn reduce_type_emits_lifetime_constraints_with_higher_ranked_equality() {
 
     premise.insert(higher_ranked_equality(
         &[TyKind::Type],
-        reference(skolem_lifetime(0, &engine), bound_type(0, &engine), &engine),
-        bound_type(0, &engine),
+        Type::new_immutable_reference(
+            Type::new_skolemized_variable(SkolemizedVariable::new(0), &engine),
+            Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
+            &engine,
+        ),
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
         &engine,
     ));
 
     let (reduced, constraints) = reduce_type_with_lifetime_skolems(
-        reference(
-            skolem_lifetime(1, &engine),
-            primitive(Primitive::Int32, &engine),
+        Type::new_immutable_reference(
+            Type::new_skolemized_variable(SkolemizedVariable::new(1), &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
             &engine,
         ),
         &premise,
@@ -242,12 +184,12 @@ async fn reduce_type_emits_lifetime_constraints_with_higher_ranked_equality() {
     .unwrap()
     .unwrap();
 
-    assert_eq!(reduced, primitive(Primitive::Int32, &engine));
+    assert_eq!(reduced, Type::new_primitive(Primitive::Int32, &engine));
     assert_eq!(
         constraints,
         Constraints::lifetimes_eq(
-            skolem_lifetime(0, &engine),
-            skolem_lifetime(1, &engine),
+            Type::new_skolemized_variable(SkolemizedVariable::new(0), &engine),
+            Type::new_skolemized_variable(SkolemizedVariable::new(1), &engine),
         )
     );
 }
@@ -262,19 +204,19 @@ async fn reduce_type_instantiates_higher_ranked_lifetime() {
 
     premise.insert(higher_ranked_equality(
         &[TyKind::Lifetime],
-        reference(
-            bound_lifetime(0, &engine),
-            primitive(Primitive::Bool, &engine),
+        Type::new_immutable_reference(
+            Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
             &engine,
         ),
-        primitive(Primitive::Bool, &engine),
+        Type::new_primitive(Primitive::Bool, &engine),
         &engine,
     ));
 
     let (reduced, constraints) = reduce_type_with_lifetime_skolems(
-        reference(
-            skolem_lifetime(0, &engine),
-            primitive(Primitive::Bool, &engine),
+        Type::new_immutable_reference(
+            Type::new_skolemized_variable(SkolemizedVariable::new(0), &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
             &engine,
         ),
         &premise,
@@ -285,7 +227,7 @@ async fn reduce_type_instantiates_higher_ranked_lifetime() {
     .unwrap()
     .unwrap();
 
-    assert_eq!(reduced, primitive(Primitive::Bool, &engine));
+    assert_eq!(reduced, Type::new_primitive(Primitive::Bool, &engine));
     assert_eq!(constraints, Constraints::default());
 }
 
@@ -299,23 +241,23 @@ async fn reduce_type_substitutes_higher_ranked_lifetime_in_output() {
 
     premise.insert(higher_ranked_equality(
         &[TyKind::Lifetime],
-        reference(
-            bound_lifetime(0, &engine),
-            primitive(Primitive::Bool, &engine),
+        Type::new_immutable_reference(
+            Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
             &engine,
         ),
-        reference(
-            bound_lifetime(0, &engine),
-            primitive(Primitive::Int32, &engine),
+        Type::new_immutable_reference(
+            Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
             &engine,
         ),
         &engine,
     ));
 
     let (reduced, constraints) = reduce_type_with_lifetime_skolems(
-        reference(
-            skolem_lifetime(0, &engine),
-            primitive(Primitive::Bool, &engine),
+        Type::new_immutable_reference(
+            Type::new_skolemized_variable(SkolemizedVariable::new(0), &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
             &engine,
         ),
         &premise,
@@ -328,10 +270,10 @@ async fn reduce_type_substitutes_higher_ranked_lifetime_in_output() {
 
     assert_eq!(
         reduced,
-        reference(
-            skolem_lifetime(0, &engine),
-            primitive(Primitive::Int32, &engine),
-            &engine,
+        Type::new_immutable_reference(
+            Type::new_skolemized_variable(SkolemizedVariable::new(0), &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            &engine
         )
     );
     assert_eq!(constraints, Constraints::default());
@@ -348,56 +290,59 @@ async fn reduce_type_substitutes_multiple_higher_ranked_lifetimes() {
 
     premise.insert(higher_ranked_equality(
         &[TyKind::Lifetime, TyKind::Lifetime],
-        tuple(
-            &[
-                reference(
-                    bound_lifetime(0, &engine),
-                    primitive(Primitive::Bool, &engine),
+        Type::new_tuple(
+            [
+                Type::new_immutable_reference(
+                    Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
+                    Type::new_primitive(Primitive::Bool, &engine),
                     &engine,
                 ),
-                reference(
-                    bound_lifetime(1, &engine),
-                    primitive(Primitive::Int32, &engine),
+                Type::new_immutable_reference(
+                    Type::new_bound_variable(BoundVariable::new(0, 1), &engine),
+                    Type::new_primitive(Primitive::Int32, &engine),
                     &engine,
                 ),
             ],
-            &[],
             &engine,
         ),
-        tuple(
-            &[
-                reference(
-                    bound_lifetime(1, &engine),
-                    primitive(Primitive::Uint64, &engine),
+        Type::new_tuple(
+            [
+                Type::new_immutable_reference(
+                    Type::new_bound_variable(BoundVariable::new(0, 1), &engine),
+                    Type::new_primitive(Primitive::Uint64, &engine),
                     &engine,
                 ),
-                reference(
-                    bound_lifetime(0, &engine),
-                    primitive(Primitive::Int32, &engine),
+                Type::new_immutable_reference(
+                    Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
+                    Type::new_primitive(Primitive::Int32, &engine),
                     &engine,
                 ),
             ],
-            &[],
             &engine,
         ),
         &engine,
     ));
 
     let (reduced, constraints) = reduce_type_with_lifetime_skolems(
-        tuple(
-            &[
-                reference(
-                    skolem_lifetime(0, &engine),
-                    primitive(Primitive::Bool, &engine),
+        Type::new_tuple(
+            [
+                Type::new_immutable_reference(
+                    Type::new_skolemized_variable(
+                        SkolemizedVariable::new(0),
+                        &engine,
+                    ),
+                    Type::new_primitive(Primitive::Bool, &engine),
                     &engine,
                 ),
-                reference(
-                    skolem_lifetime(1, &engine),
-                    primitive(Primitive::Int32, &engine),
+                Type::new_immutable_reference(
+                    Type::new_skolemized_variable(
+                        SkolemizedVariable::new(1),
+                        &engine,
+                    ),
+                    Type::new_primitive(Primitive::Int32, &engine),
                     &engine,
                 ),
             ],
-            &[],
             &engine,
         ),
         &premise,
@@ -410,21 +355,26 @@ async fn reduce_type_substitutes_multiple_higher_ranked_lifetimes() {
 
     assert_eq!(
         reduced,
-        tuple(
-            &[
-                reference(
-                    skolem_lifetime(1, &engine),
-                    primitive(Primitive::Uint64, &engine),
-                    &engine,
+        Type::new_tuple(
+            [
+                Type::new_immutable_reference(
+                    Type::new_skolemized_variable(
+                        SkolemizedVariable::new(1),
+                        &engine
+                    ),
+                    Type::new_primitive(Primitive::Uint64, &engine),
+                    &engine
                 ),
-                reference(
-                    skolem_lifetime(0, &engine),
-                    primitive(Primitive::Int32, &engine),
-                    &engine,
+                Type::new_immutable_reference(
+                    Type::new_skolemized_variable(
+                        SkolemizedVariable::new(0),
+                        &engine
+                    ),
+                    Type::new_primitive(Primitive::Int32, &engine),
+                    &engine
                 ),
             ],
-            &[],
-            &engine,
+            &engine
         )
     );
     assert_eq!(constraints, Constraints::default());
@@ -440,41 +390,45 @@ async fn reduce_type_emits_constraints_for_repeated_higher_ranked_lifetime() {
 
     premise.insert(higher_ranked_equality(
         &[TyKind::Lifetime],
-        tuple(
-            &[
-                reference(
-                    bound_lifetime(0, &engine),
-                    primitive(Primitive::Int32, &engine),
+        Type::new_tuple(
+            [
+                Type::new_immutable_reference(
+                    Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
+                    Type::new_primitive(Primitive::Int32, &engine),
                     &engine,
                 ),
-                reference(
-                    bound_lifetime(0, &engine),
-                    primitive(Primitive::Int32, &engine),
+                Type::new_immutable_reference(
+                    Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
+                    Type::new_primitive(Primitive::Int32, &engine),
                     &engine,
                 ),
             ],
-            &[],
             &engine,
         ),
-        primitive(Primitive::Bool, &engine),
+        Type::new_primitive(Primitive::Bool, &engine),
         &engine,
     ));
 
     let (reduced, constraints) = reduce_type_with_lifetime_skolems(
-        tuple(
-            &[
-                reference(
-                    skolem_lifetime(1, &engine),
-                    primitive(Primitive::Int32, &engine),
+        Type::new_tuple(
+            [
+                Type::new_immutable_reference(
+                    Type::new_skolemized_variable(
+                        SkolemizedVariable::new(1),
+                        &engine,
+                    ),
+                    Type::new_primitive(Primitive::Int32, &engine),
                     &engine,
                 ),
-                reference(
-                    skolem_lifetime(2, &engine),
-                    primitive(Primitive::Int32, &engine),
+                Type::new_immutable_reference(
+                    Type::new_skolemized_variable(
+                        SkolemizedVariable::new(2),
+                        &engine,
+                    ),
+                    Type::new_primitive(Primitive::Int32, &engine),
                     &engine,
                 ),
             ],
-            &[],
             &engine,
         ),
         &premise,
@@ -485,12 +439,12 @@ async fn reduce_type_emits_constraints_for_repeated_higher_ranked_lifetime() {
     .unwrap()
     .unwrap();
 
-    assert_eq!(reduced, primitive(Primitive::Bool, &engine));
+    assert_eq!(reduced, Type::new_primitive(Primitive::Bool, &engine));
     assert_eq!(
         constraints,
         Constraints::lifetimes_eq(
-            skolem_lifetime(1, &engine),
-            skolem_lifetime(2, &engine),
+            Type::new_skolemized_variable(SkolemizedVariable::new(1), &engine),
+            Type::new_skolemized_variable(SkolemizedVariable::new(2), &engine),
         )
     );
 }
@@ -506,41 +460,45 @@ async fn reduce_type_emits_constraints_for_repeated_lifetime_with_type_output()
 
     premise.insert(higher_ranked_equality(
         &[TyKind::Lifetime, TyKind::Type],
-        tuple(
-            &[
-                reference(
-                    bound_lifetime(0, &engine),
-                    bound_type(1, &engine),
+        Type::new_tuple(
+            [
+                Type::new_immutable_reference(
+                    Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
+                    Type::new_bound_variable(BoundVariable::new(0, 1), &engine),
                     &engine,
                 ),
-                reference(
-                    bound_lifetime(0, &engine),
-                    bound_type(1, &engine),
+                Type::new_immutable_reference(
+                    Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
+                    Type::new_bound_variable(BoundVariable::new(0, 1), &engine),
                     &engine,
                 ),
             ],
-            &[],
             &engine,
         ),
-        bound_type(1, &engine),
+        Type::new_bound_variable(BoundVariable::new(0, 1), &engine),
         &engine,
     ));
 
     let (reduced, constraints) = reduce_type_with_lifetime_skolems(
-        tuple(
-            &[
-                reference(
-                    skolem_lifetime(1, &engine),
-                    primitive(Primitive::Uint64, &engine),
+        Type::new_tuple(
+            [
+                Type::new_immutable_reference(
+                    Type::new_skolemized_variable(
+                        SkolemizedVariable::new(1),
+                        &engine,
+                    ),
+                    Type::new_primitive(Primitive::Uint64, &engine),
                     &engine,
                 ),
-                reference(
-                    skolem_lifetime(2, &engine),
-                    primitive(Primitive::Uint64, &engine),
+                Type::new_immutable_reference(
+                    Type::new_skolemized_variable(
+                        SkolemizedVariable::new(2),
+                        &engine,
+                    ),
+                    Type::new_primitive(Primitive::Uint64, &engine),
                     &engine,
                 ),
             ],
-            &[],
             &engine,
         ),
         &premise,
@@ -551,12 +509,12 @@ async fn reduce_type_emits_constraints_for_repeated_lifetime_with_type_output()
     .unwrap()
     .unwrap();
 
-    assert_eq!(reduced, primitive(Primitive::Uint64, &engine));
+    assert_eq!(reduced, Type::new_primitive(Primitive::Uint64, &engine));
     assert_eq!(
         constraints,
         Constraints::lifetimes_eq(
-            skolem_lifetime(1, &engine),
-            skolem_lifetime(2, &engine),
+            Type::new_skolemized_variable(SkolemizedVariable::new(1), &engine),
+            Type::new_skolemized_variable(SkolemizedVariable::new(2), &engine),
         )
     );
 }
@@ -571,13 +529,19 @@ async fn reduce_type_instantiates_higher_ranked_equality() {
 
     premise.insert(higher_ranked_equality(
         &[TyKind::Type],
-        tuple(&[bound_type(0, &engine)], &[], &engine),
-        bound_type(0, &engine),
+        Type::new_tuple(
+            [Type::new_bound_variable(BoundVariable::new(0, 0), &engine)],
+            &engine,
+        ),
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
         &engine,
     ));
 
     let (reduced, constraints) = reduce_type(
-        tuple(&[primitive(Primitive::Bool, &engine)], &[], &engine),
+        Type::new_tuple(
+            [Type::new_primitive(Primitive::Bool, &engine)],
+            &engine,
+        ),
         &premise,
         &engine,
     )
@@ -585,7 +549,7 @@ async fn reduce_type_instantiates_higher_ranked_equality() {
     .unwrap()
     .unwrap();
 
-    assert_eq!(reduced, primitive(Primitive::Bool, &engine));
+    assert_eq!(reduced, Type::new_primitive(Primitive::Bool, &engine));
     assert_eq!(constraints, Constraints::default());
 }
 
@@ -599,27 +563,31 @@ async fn reduce_type_substitutes_multiple_higher_ranked_variables() {
 
     premise.insert(higher_ranked_equality(
         &[TyKind::Type, TyKind::Type],
-        tuple(
-            &[
-                bound_type(0, &engine),
-                bound_type(1, &engine),
-                primitive(Primitive::Bool, &engine),
+        Type::new_tuple(
+            [
+                Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
+                Type::new_bound_variable(BoundVariable::new(0, 1), &engine),
+                Type::new_primitive(Primitive::Bool, &engine),
             ],
-            &[],
             &engine,
         ),
-        tuple(&[bound_type(1, &engine), bound_type(0, &engine)], &[], &engine),
+        Type::new_tuple(
+            [
+                Type::new_bound_variable(BoundVariable::new(0, 1), &engine),
+                Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
+            ],
+            &engine,
+        ),
         &engine,
     ));
 
     let (reduced, constraints) = reduce_type(
-        tuple(
-            &[
-                primitive(Primitive::Int8, &engine),
-                primitive(Primitive::Float32, &engine),
-                primitive(Primitive::Bool, &engine),
+        Type::new_tuple(
+            [
+                Type::new_primitive(Primitive::Int8, &engine),
+                Type::new_primitive(Primitive::Float32, &engine),
+                Type::new_primitive(Primitive::Bool, &engine),
             ],
-            &[],
             &engine,
         ),
         &premise,
@@ -631,13 +599,12 @@ async fn reduce_type_substitutes_multiple_higher_ranked_variables() {
 
     assert_eq!(
         reduced,
-        tuple(
-            &[
-                primitive(Primitive::Float32, &engine),
-                primitive(Primitive::Int8, &engine),
+        Type::new_tuple(
+            [
+                Type::new_primitive(Primitive::Float32, &engine),
+                Type::new_primitive(Primitive::Int8, &engine),
             ],
-            &[],
-            &engine,
+            &engine
         )
     );
     assert_eq!(constraints, Constraints::default());
@@ -653,39 +620,40 @@ async fn reduce_type_continues_after_higher_ranked_equality() {
 
     premise.insert(higher_ranked_equality(
         &[TyKind::Type],
-        tuple(&[bound_type(0, &engine)], &[], &engine),
-        bound_type(0, &engine),
+        Type::new_tuple(
+            [Type::new_bound_variable(BoundVariable::new(0, 0), &engine)],
+            &engine,
+        ),
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine),
         &engine,
     ));
 
-    let reducible = tuple(
-        &[tuple(
-            &[
-                primitive(Primitive::Int32, &engine),
-                primitive(Primitive::Bool, &engine),
+    let reducible = Type::new_tuple_with_unpack(
+        [Type::new_tuple(
+            [
+                Type::new_primitive(Primitive::Int32, &engine),
+                Type::new_primitive(Primitive::Bool, &engine),
             ],
-            &[],
             &engine,
         )],
-        &[0],
+        [0],
         &engine,
     );
 
     let (reduced, constraints) =
-        reduce_type(tuple(&[reducible], &[], &engine), &premise, &engine)
+        reduce_type(Type::new_tuple([reducible], &engine), &premise, &engine)
             .await
             .unwrap()
             .unwrap();
 
     assert_eq!(
         reduced,
-        tuple(
-            &[
-                primitive(Primitive::Int32, &engine),
-                primitive(Primitive::Bool, &engine),
+        Type::new_tuple(
+            [
+                Type::new_primitive(Primitive::Int32, &engine),
+                Type::new_primitive(Primitive::Bool, &engine),
             ],
-            &[],
-            &engine,
+            &engine
         )
     );
     assert_eq!(constraints, Constraints::default());
@@ -700,23 +668,26 @@ async fn reduce_type_transitively_reduces_equality_chain() {
     let mut premise = Premise::default();
 
     premise.insert(equality(
-        primitive(Primitive::Int8, &engine),
-        primitive(Primitive::Int16, &engine),
+        Type::new_primitive(Primitive::Int8, &engine),
+        Type::new_primitive(Primitive::Int16, &engine),
         &engine,
     ));
     premise.insert(equality(
-        primitive(Primitive::Int16, &engine),
-        primitive(Primitive::Bool, &engine),
+        Type::new_primitive(Primitive::Int16, &engine),
+        Type::new_primitive(Primitive::Bool, &engine),
         &engine,
     ));
 
-    let (reduced, constraints) =
-        reduce_type(primitive(Primitive::Int8, &engine), &premise, &engine)
-            .await
-            .unwrap()
-            .unwrap();
+    let (reduced, constraints) = reduce_type(
+        Type::new_primitive(Primitive::Int8, &engine),
+        &premise,
+        &engine,
+    )
+    .await
+    .unwrap()
+    .unwrap();
 
-    assert_eq!(reduced, primitive(Primitive::Bool, &engine));
+    assert_eq!(reduced, Type::new_primitive(Primitive::Bool, &engine));
     assert_eq!(constraints, Constraints::default());
 }
 
@@ -729,37 +700,38 @@ async fn reduce_type_reduces_type_reached_by_equality() {
     let mut premise = Premise::default();
 
     premise.insert(equality(
-        primitive(Primitive::Int8, &engine),
-        tuple(
-            &[tuple(
-                &[
-                    primitive(Primitive::Int32, &engine),
-                    primitive(Primitive::Bool, &engine),
+        Type::new_primitive(Primitive::Int8, &engine),
+        Type::new_tuple_with_unpack(
+            [Type::new_tuple(
+                [
+                    Type::new_primitive(Primitive::Int32, &engine),
+                    Type::new_primitive(Primitive::Bool, &engine),
                 ],
-                &[],
                 &engine,
             )],
-            &[0],
+            [0],
             &engine,
         ),
         &engine,
     ));
 
-    let (reduced, constraints) =
-        reduce_type(primitive(Primitive::Int8, &engine), &premise, &engine)
-            .await
-            .unwrap()
-            .unwrap();
+    let (reduced, constraints) = reduce_type(
+        Type::new_primitive(Primitive::Int8, &engine),
+        &premise,
+        &engine,
+    )
+    .await
+    .unwrap()
+    .unwrap();
 
     assert_eq!(
         reduced,
-        tuple(
-            &[
-                primitive(Primitive::Int32, &engine),
-                primitive(Primitive::Bool, &engine),
+        Type::new_tuple(
+            [
+                Type::new_primitive(Primitive::Int32, &engine),
+                Type::new_primitive(Primitive::Bool, &engine),
             ],
-            &[],
-            &engine,
+            &engine
         )
     );
     assert_eq!(constraints, Constraints::default());
@@ -774,10 +746,15 @@ async fn reduce_type_overflows_on_self_expanding_equality() {
     let mut premise = Premise::default();
 
     premise.insert(equality(
-        skolem_lifetime(1, &engine),
-        tuple(
-            &[primitive(Primitive::Bool, &engine), skolem_lifetime(1, &engine)],
-            &[],
+        Type::new_skolemized_variable(SkolemizedVariable::new(1), &engine),
+        Type::new_tuple(
+            [
+                Type::new_primitive(Primitive::Bool, &engine),
+                Type::new_skolemized_variable(
+                    SkolemizedVariable::new(1),
+                    &engine,
+                ),
+            ],
             &engine,
         ),
         &engine,
@@ -785,7 +762,7 @@ async fn reduce_type_overflows_on_self_expanding_equality() {
 
     assert!(
         reduce_type_with_lifetime_skolems(
-            skolem_lifetime(1, &engine),
+            Type::new_skolemized_variable(SkolemizedVariable::new(1), &engine),
             &premise,
             &engine,
             2,

--- a/compiler/semantic/solver/src/subtype/test.rs
+++ b/compiler/semantic/solver/src/subtype/test.rs
@@ -1,25 +1,16 @@
-use std::sync::Arc;
-
-use pernixc_qbice::{Engine, InMemoryFactory, TrackedEngine};
+use pernixc_qbice::{TrackedEngine, create_minimal_engine as create_engine};
 use pernixc_symbol::GlobalSymbolID;
 use pernixc_type::{
     predicate::Subtype,
     substitution::Substitution,
     r#type::{
         Type,
-        bound::{Binder, BoundVariable},
-        constructor::{
-            Application, Constructor, FunctionPointer, InstanceAssociated,
-            Lifetime, Mutability, Primitive, Reference, Tuple,
-        },
-        kind::TyKind,
+        bound::BoundVariable,
+        constructor::{Lifetime, Mutability, Primitive},
     },
     variance::Variance,
 };
-use qbice::{
-    serialize::Plugin, stable_hash::SeededStableHasherBuilder,
-    storage::intern::Interned,
-};
+use qbice::storage::intern::Interned;
 
 use crate::{
     constraints::Constraints,
@@ -27,85 +18,6 @@ use crate::{
     solver::{OverflowError, Solver},
     subtype::Step,
 };
-
-async fn create_engine() -> TrackedEngine {
-    let engine = Engine::new_with(
-        Plugin::default(),
-        InMemoryFactory,
-        SeededStableHasherBuilder::new(0),
-    )
-    .await
-    .unwrap();
-
-    Arc::new(engine).tracked().await
-}
-
-fn primitive(primitive: Primitive, engine: &TrackedEngine) -> Interned<Type> {
-    engine.intern(Type::Application(Application::new(
-        Constructor::Primitive(primitive),
-        engine.intern_unsized(Vec::<Interned<Type>>::new()),
-    )))
-}
-
-fn lifetime(lifetime: Lifetime, engine: &TrackedEngine) -> Interned<Type> {
-    engine.intern(Type::Application(Application::new(
-        Constructor::Lifetime(lifetime),
-        engine.intern_unsized(Vec::<Interned<Type>>::new()),
-    )))
-}
-
-fn bound_lifetime(index: usize, engine: &TrackedEngine) -> Interned<Type> {
-    engine.intern(Type::BoundVariable(BoundVariable::new(0, index)))
-}
-
-fn tuple(
-    arguments: Vec<Interned<Type>>,
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    engine.intern(Type::Application(Application::new(
-        Constructor::Tuple(Tuple::new(engine.intern_unsized(Vec::new()))),
-        engine.intern_unsized(arguments),
-    )))
-}
-
-fn unit(engine: &TrackedEngine) -> Interned<Type> { tuple(Vec::new(), engine) }
-
-fn reference(
-    lifetime: Interned<Type>,
-    pointee: Interned<Type>,
-    mutability: Mutability,
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    engine.intern(Type::Application(Application::new(
-        Constructor::Reference(Reference::new(mutability)),
-        engine.intern_unsized(vec![lifetime, pointee]),
-    )))
-}
-
-fn function_pointer(
-    lifetimes: usize,
-    arguments: Vec<Interned<Type>>,
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    engine.intern(Type::Application(Application::new(
-        Constructor::FunctionPointer(FunctionPointer::new(Binder::new(
-            engine.intern_unsized(vec![TyKind::Lifetime; lifetimes]),
-        ))),
-        engine.intern_unsized(arguments),
-    )))
-}
-
-fn instance_associated(
-    arguments: Vec<Interned<Type>>,
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    engine.intern(Type::Application(Application::new(
-        Constructor::InstanceAssociated(InstanceAssociated::new(
-            GlobalSymbolID::default(),
-        )),
-        engine.intern_unsized(arguments),
-    )))
-}
 
 async fn destructure_application(
     lesser: &Interned<Type>,
@@ -187,13 +99,17 @@ fn assert_no_variables_in_step(
 #[tokio::test]
 async fn instance_associated_arguments_must_be_solved_immediately() {
     let engine = create_engine().await;
-    let common_instance = primitive(Primitive::Bool, &engine);
-    let lesser = instance_associated(
-        vec![common_instance.clone(), primitive(Primitive::Int32, &engine)],
+    let common_instance = Type::new_primitive(Primitive::Bool, &engine);
+    let lesser = Type::new_instance_associated(
+        GlobalSymbolID::default(),
+        common_instance.clone(),
+        [Type::new_primitive(Primitive::Int32, &engine)],
         &engine,
     );
-    let greater = instance_associated(
-        vec![common_instance, primitive(Primitive::Float32, &engine)],
+    let greater = Type::new_instance_associated(
+        GlobalSymbolID::default(),
+        common_instance,
+        [Type::new_primitive(Primitive::Float32, &engine)],
         &engine,
     );
 
@@ -206,15 +122,19 @@ async fn instance_associated_arguments_must_be_solved_immediately() {
 #[tokio::test]
 async fn solved_instance_associated_arguments_are_not_deferred() {
     let engine = create_engine().await;
-    let common_instance = primitive(Primitive::Bool, &engine);
-    let static_lifetime = lifetime(Lifetime::Static, &engine);
-    let erased_lifetime = lifetime(Lifetime::Erased, &engine);
-    let lesser = instance_associated(
-        vec![common_instance.clone(), static_lifetime.clone()],
+    let common_instance = Type::new_primitive(Primitive::Bool, &engine);
+    let static_lifetime = Type::new_lifetime(Lifetime::Static, &engine);
+    let erased_lifetime = Type::new_lifetime(Lifetime::Erased, &engine);
+    let lesser = Type::new_instance_associated(
+        GlobalSymbolID::default(),
+        common_instance.clone(),
+        [static_lifetime.clone()],
         &engine,
     );
-    let greater = instance_associated(
-        vec![common_instance, erased_lifetime.clone()],
+    let greater = Type::new_instance_associated(
+        GlobalSymbolID::default(),
+        common_instance,
+        [erased_lifetime.clone()],
         &engine,
     );
 
@@ -238,12 +158,12 @@ async fn solved_instance_associated_arguments_are_not_deferred() {
 #[tokio::test]
 async fn tuple_arguments_follow_parent_covariance() {
     let engine = create_engine().await;
-    let static_lifetime = lifetime(Lifetime::Static, &engine);
-    let erased_lifetime = lifetime(Lifetime::Erased, &engine);
+    let static_lifetime = Type::new_lifetime(Lifetime::Static, &engine);
+    let erased_lifetime = Type::new_lifetime(Lifetime::Erased, &engine);
 
     let constraints = resolve_one(
-        tuple(vec![static_lifetime.clone()], &engine),
-        tuple(vec![erased_lifetime.clone()], &engine),
+        Type::new_tuple(vec![static_lifetime.clone()], &engine),
+        Type::new_tuple(vec![erased_lifetime.clone()], &engine),
         Variance::Covariant,
         &engine,
     )
@@ -262,12 +182,12 @@ async fn tuple_arguments_follow_parent_covariance() {
 #[tokio::test]
 async fn tuple_arguments_flip_under_parent_contravariance() {
     let engine = create_engine().await;
-    let static_lifetime = lifetime(Lifetime::Static, &engine);
-    let erased_lifetime = lifetime(Lifetime::Erased, &engine);
+    let static_lifetime = Type::new_lifetime(Lifetime::Static, &engine);
+    let erased_lifetime = Type::new_lifetime(Lifetime::Erased, &engine);
 
     let constraints = resolve_one(
-        tuple(vec![static_lifetime.clone()], &engine),
-        tuple(vec![erased_lifetime.clone()], &engine),
+        Type::new_tuple(vec![static_lifetime.clone()], &engine),
+        Type::new_tuple(vec![erased_lifetime.clone()], &engine),
         Variance::Contravariant,
         &engine,
     )
@@ -286,12 +206,12 @@ async fn tuple_arguments_flip_under_parent_contravariance() {
 #[tokio::test]
 async fn tuple_arguments_become_equal_under_parent_invariance() {
     let engine = create_engine().await;
-    let static_lifetime = lifetime(Lifetime::Static, &engine);
-    let erased_lifetime = lifetime(Lifetime::Erased, &engine);
+    let static_lifetime = Type::new_lifetime(Lifetime::Static, &engine);
+    let erased_lifetime = Type::new_lifetime(Lifetime::Erased, &engine);
 
     let constraints = resolve_one(
-        tuple(vec![static_lifetime.clone()], &engine),
-        tuple(vec![erased_lifetime.clone()], &engine),
+        Type::new_tuple(vec![static_lifetime.clone()], &engine),
+        Type::new_tuple(vec![erased_lifetime.clone()], &engine),
         Variance::Invariant,
         &engine,
     )
@@ -312,8 +232,14 @@ async fn tuple_arguments_are_ignored_under_parent_bivariance() {
     let engine = create_engine().await;
 
     let constraints = resolve_one(
-        tuple(vec![lifetime(Lifetime::Static, &engine)], &engine),
-        tuple(vec![lifetime(Lifetime::Erased, &engine)], &engine),
+        Type::new_tuple(
+            vec![Type::new_lifetime(Lifetime::Static, &engine)],
+            &engine,
+        ),
+        Type::new_tuple(
+            vec![Type::new_lifetime(Lifetime::Erased, &engine)],
+            &engine,
+        ),
         Variance::Bivariant,
         &engine,
     )
@@ -329,15 +255,16 @@ async fn tuple_arguments_are_ignored_under_parent_bivariance() {
 #[tokio::test]
 async fn mutable_reference_pointees_are_invariant() {
     let engine = create_engine().await;
-    let static_lifetime = lifetime(Lifetime::Static, &engine);
-    let erased_lifetime = lifetime(Lifetime::Erased, &engine);
-    let common_reference_lifetime = lifetime(Lifetime::Static, &engine);
-    let bool_type = primitive(Primitive::Bool, &engine);
+    let static_lifetime = Type::new_lifetime(Lifetime::Static, &engine);
+    let erased_lifetime = Type::new_lifetime(Lifetime::Erased, &engine);
+    let common_reference_lifetime =
+        Type::new_lifetime(Lifetime::Static, &engine);
+    let bool_type = Type::new_primitive(Primitive::Bool, &engine);
 
     let constraints = resolve_one(
-        reference(
+        Type::new_reference(
             common_reference_lifetime.clone(),
-            reference(
+            Type::new_reference(
                 static_lifetime.clone(),
                 bool_type.clone(),
                 Mutability::Immutable,
@@ -346,9 +273,9 @@ async fn mutable_reference_pointees_are_invariant() {
             Mutability::Mutable,
             &engine,
         ),
-        reference(
+        Type::new_reference(
             common_reference_lifetime,
-            reference(
+            Type::new_reference(
                 erased_lifetime.clone(),
                 bool_type,
                 Mutability::Immutable,
@@ -377,47 +304,50 @@ async fn mutable_reference_pointees_are_invariant() {
 #[tokio::test]
 async fn higher_ranked_lifetime_arguments_can_split() {
     let engine = create_engine().await;
-    let u32_type = primitive(Primitive::Uint32, &engine);
-    let lhs_lifetime = bound_lifetime(0, &engine);
-    let rhs_first_lifetime = bound_lifetime(0, &engine);
-    let rhs_second_lifetime = bound_lifetime(1, &engine);
+    let u32_type = Type::new_primitive(Primitive::Uint32, &engine);
+    let lhs_lifetime =
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine);
+    let rhs_first_lifetime =
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine);
+    let rhs_second_lifetime =
+        Type::new_bound_variable(BoundVariable::new(0, 1), &engine);
 
-    let lesser = function_pointer(
+    let lesser = Type::new_function_pointer_with_higher_ranked_lifetimes(
         1,
-        vec![
-            reference(
+        [
+            Type::new_reference(
                 lhs_lifetime.clone(),
                 u32_type.clone(),
                 Mutability::Immutable,
                 &engine,
             ),
-            reference(
+            Type::new_reference(
                 lhs_lifetime,
                 u32_type.clone(),
                 Mutability::Immutable,
                 &engine,
             ),
-            unit(&engine),
         ],
+        Type::new_tuple([], &engine),
         &engine,
     );
-    let greater = function_pointer(
+    let greater = Type::new_function_pointer_with_higher_ranked_lifetimes(
         2,
-        vec![
-            reference(
+        [
+            Type::new_reference(
                 rhs_first_lifetime,
                 u32_type.clone(),
                 Mutability::Immutable,
                 &engine,
             ),
-            reference(
+            Type::new_reference(
                 rhs_second_lifetime,
                 u32_type,
                 Mutability::Immutable,
                 &engine,
             ),
-            unit(&engine),
         ],
+        Type::new_tuple([], &engine),
         &engine,
     );
 
@@ -439,57 +369,60 @@ async fn higher_ranked_lifetime_arguments_can_split() {
 #[tokio::test]
 async fn higher_ranked_lifetime_return_cannot_split_argument_identity() {
     let engine = create_engine().await;
-    let u32_type = primitive(Primitive::Uint32, &engine);
-    let lhs_lifetime = bound_lifetime(0, &engine);
-    let rhs_first_lifetime = bound_lifetime(0, &engine);
-    let rhs_second_lifetime = bound_lifetime(1, &engine);
+    let u32_type = Type::new_primitive(Primitive::Uint32, &engine);
+    let lhs_lifetime =
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine);
+    let rhs_first_lifetime =
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine);
+    let rhs_second_lifetime =
+        Type::new_bound_variable(BoundVariable::new(0, 1), &engine);
 
-    let lesser = function_pointer(
+    let lesser = Type::new_function_pointer_with_higher_ranked_lifetimes(
         1,
-        vec![
-            reference(
+        [
+            Type::new_reference(
                 lhs_lifetime.clone(),
                 u32_type.clone(),
                 Mutability::Immutable,
                 &engine,
             ),
-            reference(
+            Type::new_reference(
                 lhs_lifetime.clone(),
-                u32_type.clone(),
-                Mutability::Immutable,
-                &engine,
-            ),
-            reference(
-                lhs_lifetime,
                 u32_type.clone(),
                 Mutability::Immutable,
                 &engine,
             ),
         ],
+        Type::new_reference(
+            lhs_lifetime,
+            u32_type.clone(),
+            Mutability::Immutable,
+            &engine,
+        ),
         &engine,
     );
-    let greater = function_pointer(
+    let greater = Type::new_function_pointer_with_higher_ranked_lifetimes(
         2,
-        vec![
-            reference(
+        [
+            Type::new_reference(
                 rhs_first_lifetime.clone(),
                 u32_type.clone(),
                 Mutability::Immutable,
                 &engine,
             ),
-            reference(
+            Type::new_reference(
                 rhs_second_lifetime,
                 u32_type.clone(),
                 Mutability::Immutable,
                 &engine,
             ),
-            reference(
-                rhs_first_lifetime,
-                u32_type,
-                Mutability::Immutable,
-                &engine,
-            ),
         ],
+        Type::new_reference(
+            rhs_first_lifetime,
+            u32_type,
+            Mutability::Immutable,
+            &engine,
+        ),
         &engine,
     );
 
@@ -507,34 +440,30 @@ async fn higher_ranked_lifetime_return_cannot_split_argument_identity() {
 #[tokio::test]
 async fn mixed_ranked_and_unranked_function_pointers_destructure() {
     let engine = create_engine().await;
-    let u32_type = primitive(Primitive::Uint32, &engine);
-    let ranked_lifetime = bound_lifetime(0, &engine);
-    let static_lifetime = lifetime(Lifetime::Static, &engine);
+    let u32_type = Type::new_primitive(Primitive::Uint32, &engine);
+    let ranked_lifetime =
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine);
+    let static_lifetime = Type::new_lifetime(Lifetime::Static, &engine);
 
-    let lesser = function_pointer(
+    let lesser = Type::new_function_pointer_with_higher_ranked_lifetimes(
         1,
-        vec![
-            reference(
-                ranked_lifetime,
-                u32_type.clone(),
-                Mutability::Immutable,
-                &engine,
-            ),
-            unit(&engine),
-        ],
+        [Type::new_reference(
+            ranked_lifetime,
+            u32_type.clone(),
+            Mutability::Immutable,
+            &engine,
+        )],
+        Type::new_tuple([], &engine),
         &engine,
     );
-    let greater = function_pointer(
-        0,
-        vec![
-            reference(
-                static_lifetime,
-                u32_type,
-                Mutability::Immutable,
-                &engine,
-            ),
-            unit(&engine),
-        ],
+    let greater = Type::new_function_pointer(
+        [Type::new_reference(
+            static_lifetime,
+            u32_type,
+            Mutability::Immutable,
+            &engine,
+        )],
+        Type::new_tuple([], &engine),
         &engine,
     );
 
@@ -552,34 +481,30 @@ async fn mixed_ranked_and_unranked_function_pointers_destructure() {
 #[tokio::test]
 async fn covariant_hrtb_rejects_skolem_to_external_leak() {
     let engine = create_engine().await;
-    let u32_type = primitive(Primitive::Uint32, &engine);
-    let ranked_lifetime = bound_lifetime(0, &engine);
-    let static_lifetime = lifetime(Lifetime::Static, &engine);
+    let u32_type = Type::new_primitive(Primitive::Uint32, &engine);
+    let ranked_lifetime =
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine);
+    let static_lifetime = Type::new_lifetime(Lifetime::Static, &engine);
 
-    let lesser = function_pointer(
-        0,
-        vec![
-            reference(
-                static_lifetime,
-                u32_type.clone(),
-                Mutability::Immutable,
-                &engine,
-            ),
-            unit(&engine),
-        ],
+    let lesser = Type::new_function_pointer(
+        [Type::new_reference(
+            static_lifetime,
+            u32_type.clone(),
+            Mutability::Immutable,
+            &engine,
+        )],
+        Type::new_tuple([], &engine),
         &engine,
     );
-    let greater = function_pointer(
+    let greater = Type::new_function_pointer_with_higher_ranked_lifetimes(
         1,
-        vec![
-            reference(
-                ranked_lifetime,
-                u32_type,
-                Mutability::Immutable,
-                &engine,
-            ),
-            unit(&engine),
-        ],
+        [Type::new_reference(
+            ranked_lifetime,
+            u32_type,
+            Mutability::Immutable,
+            &engine,
+        )],
+        Type::new_tuple([], &engine),
         &engine,
     );
 
@@ -598,34 +523,30 @@ async fn covariant_hrtb_rejects_skolem_to_external_leak() {
 #[tokio::test]
 async fn contravariant_top_level_variance_flips_hrtb_sides() {
     let engine = create_engine().await;
-    let u32_type = primitive(Primitive::Uint32, &engine);
-    let ranked_lifetime = bound_lifetime(0, &engine);
-    let static_lifetime = lifetime(Lifetime::Static, &engine);
+    let u32_type = Type::new_primitive(Primitive::Uint32, &engine);
+    let ranked_lifetime =
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine);
+    let static_lifetime = Type::new_lifetime(Lifetime::Static, &engine);
 
-    let lesser = function_pointer(
-        0,
-        vec![
-            reference(
-                static_lifetime,
-                u32_type.clone(),
-                Mutability::Immutable,
-                &engine,
-            ),
-            unit(&engine),
-        ],
+    let lesser = Type::new_function_pointer(
+        [Type::new_reference(
+            static_lifetime,
+            u32_type.clone(),
+            Mutability::Immutable,
+            &engine,
+        )],
+        Type::new_tuple([], &engine),
         &engine,
     );
-    let greater = function_pointer(
+    let greater = Type::new_function_pointer_with_higher_ranked_lifetimes(
         1,
-        vec![
-            reference(
-                ranked_lifetime,
-                u32_type,
-                Mutability::Immutable,
-                &engine,
-            ),
-            unit(&engine),
-        ],
+        [Type::new_reference(
+            ranked_lifetime,
+            u32_type,
+            Mutability::Immutable,
+            &engine,
+        )],
+        Type::new_tuple([], &engine),
         &engine,
     );
 
@@ -645,39 +566,42 @@ async fn contravariant_top_level_variance_flips_hrtb_sides() {
 #[tokio::test]
 async fn invariant_hrtb_uses_independent_directional_runs() {
     let engine = create_engine().await;
-    let u32_type = primitive(Primitive::Uint32, &engine);
-    let lhs_lifetime = bound_lifetime(0, &engine);
-    let rhs_lifetime = bound_lifetime(0, &engine);
+    let u32_type = Type::new_primitive(Primitive::Uint32, &engine);
+    let lhs_lifetime =
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine);
+    let rhs_lifetime =
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine);
 
-    let lesser = function_pointer(
+    let lesser = Type::new_function_pointer_with_higher_ranked_lifetimes(
         1,
-        vec![
-            reference(
-                lhs_lifetime.clone(),
-                u32_type.clone(),
-                Mutability::Immutable,
-                &engine,
-            ),
-            reference(
-                lhs_lifetime,
-                u32_type.clone(),
-                Mutability::Immutable,
-                &engine,
-            ),
-        ],
+        [Type::new_reference(
+            lhs_lifetime.clone(),
+            u32_type.clone(),
+            Mutability::Immutable,
+            &engine,
+        )],
+        Type::new_reference(
+            lhs_lifetime,
+            u32_type.clone(),
+            Mutability::Immutable,
+            &engine,
+        ),
         &engine,
     );
-    let greater = function_pointer(
+    let greater = Type::new_function_pointer_with_higher_ranked_lifetimes(
         1,
-        vec![
-            reference(
-                rhs_lifetime.clone(),
-                u32_type.clone(),
-                Mutability::Immutable,
-                &engine,
-            ),
-            reference(rhs_lifetime, u32_type, Mutability::Immutable, &engine),
-        ],
+        [Type::new_reference(
+            rhs_lifetime.clone(),
+            u32_type.clone(),
+            Mutability::Immutable,
+            &engine,
+        )],
+        Type::new_reference(
+            rhs_lifetime,
+            u32_type,
+            Mutability::Immutable,
+            &engine,
+        ),
         &engine,
     );
 
@@ -697,34 +621,30 @@ async fn invariant_hrtb_uses_independent_directional_runs() {
 #[tokio::test]
 async fn hrtb_step_does_not_expose_internal_variables() {
     let engine = create_engine().await;
-    let u32_type = primitive(Primitive::Uint32, &engine);
-    let ranked_lifetime = bound_lifetime(0, &engine);
-    let static_lifetime = lifetime(Lifetime::Static, &engine);
+    let u32_type = Type::new_primitive(Primitive::Uint32, &engine);
+    let ranked_lifetime =
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine);
+    let static_lifetime = Type::new_lifetime(Lifetime::Static, &engine);
 
-    let lesser = function_pointer(
-        0,
-        vec![
-            unit(&engine),
-            reference(
-                static_lifetime,
-                u32_type.clone(),
-                Mutability::Immutable,
-                &engine,
-            ),
-        ],
+    let lesser = Type::new_function_pointer(
+        [Type::new_tuple([], &engine)],
+        Type::new_reference(
+            static_lifetime,
+            u32_type.clone(),
+            Mutability::Immutable,
+            &engine,
+        ),
         &engine,
     );
-    let greater = function_pointer(
+    let greater = Type::new_function_pointer_with_higher_ranked_lifetimes(
         1,
-        vec![
-            unit(&engine),
-            reference(
-                ranked_lifetime,
-                u32_type,
-                Mutability::Immutable,
-                &engine,
-            ),
-        ],
+        [Type::new_tuple([], &engine)],
+        Type::new_reference(
+            ranked_lifetime,
+            u32_type,
+            Mutability::Immutable,
+            &engine,
+        ),
         &engine,
     );
 
@@ -746,34 +666,30 @@ async fn hrtb_step_does_not_expose_internal_variables() {
 #[tokio::test]
 async fn external_to_skolem_return_obligation_rewrites_to_static() {
     let engine = create_engine().await;
-    let u32_type = primitive(Primitive::Uint32, &engine);
-    let ranked_lifetime = bound_lifetime(0, &engine);
-    let static_lifetime = lifetime(Lifetime::Static, &engine);
+    let u32_type = Type::new_primitive(Primitive::Uint32, &engine);
+    let ranked_lifetime =
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine);
+    let static_lifetime = Type::new_lifetime(Lifetime::Static, &engine);
 
-    let lesser = function_pointer(
-        0,
-        vec![
-            unit(&engine),
-            reference(
-                static_lifetime.clone(),
-                u32_type.clone(),
-                Mutability::Immutable,
-                &engine,
-            ),
-        ],
+    let lesser = Type::new_function_pointer(
+        [Type::new_tuple([], &engine)],
+        Type::new_reference(
+            static_lifetime.clone(),
+            u32_type.clone(),
+            Mutability::Immutable,
+            &engine,
+        ),
         &engine,
     );
-    let greater = function_pointer(
+    let greater = Type::new_function_pointer_with_higher_ranked_lifetimes(
         1,
-        vec![
-            unit(&engine),
-            reference(
-                ranked_lifetime,
-                u32_type,
-                Mutability::Immutable,
-                &engine,
-            ),
-        ],
+        [Type::new_tuple([], &engine)],
+        Type::new_reference(
+            ranked_lifetime,
+            u32_type,
+            Mutability::Immutable,
+            &engine,
+        ),
         &engine,
     );
 
@@ -800,39 +716,42 @@ async fn external_to_skolem_return_obligation_rewrites_to_static() {
 #[tokio::test]
 async fn bivariant_hrtb_function_pointers_do_not_emit_work() {
     let engine = create_engine().await;
-    let u32_type = primitive(Primitive::Uint32, &engine);
-    let lhs_lifetime = bound_lifetime(0, &engine);
-    let rhs_lifetime = bound_lifetime(0, &engine);
+    let u32_type = Type::new_primitive(Primitive::Uint32, &engine);
+    let lhs_lifetime =
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine);
+    let rhs_lifetime =
+        Type::new_bound_variable(BoundVariable::new(0, 0), &engine);
 
-    let lesser = function_pointer(
+    let lesser = Type::new_function_pointer_with_higher_ranked_lifetimes(
         1,
-        vec![
-            reference(
-                lhs_lifetime.clone(),
-                u32_type.clone(),
-                Mutability::Immutable,
-                &engine,
-            ),
-            reference(
-                lhs_lifetime,
-                u32_type.clone(),
-                Mutability::Immutable,
-                &engine,
-            ),
-        ],
+        [Type::new_reference(
+            lhs_lifetime.clone(),
+            u32_type.clone(),
+            Mutability::Immutable,
+            &engine,
+        )],
+        Type::new_reference(
+            lhs_lifetime,
+            u32_type.clone(),
+            Mutability::Immutable,
+            &engine,
+        ),
         &engine,
     );
-    let greater = function_pointer(
+    let greater = Type::new_function_pointer_with_higher_ranked_lifetimes(
         1,
-        vec![
-            reference(
-                rhs_lifetime.clone(),
-                u32_type.clone(),
-                Mutability::Immutable,
-                &engine,
-            ),
-            reference(rhs_lifetime, u32_type, Mutability::Immutable, &engine),
-        ],
+        [Type::new_reference(
+            rhs_lifetime.clone(),
+            u32_type.clone(),
+            Mutability::Immutable,
+            &engine,
+        )],
+        Type::new_reference(
+            rhs_lifetime,
+            u32_type,
+            Mutability::Immutable,
+            &engine,
+        ),
         &engine,
     );
 

--- a/compiler/semantic/type/src/type.rs
+++ b/compiler/semantic/type/src/type.rs
@@ -1,12 +1,22 @@
 use enum_as_inner::EnumAsInner;
 use pernixc_qbice::TrackedEngine;
-use qbice::{Decode, Encode, Identifiable, StableHash};
+use pernixc_symbol::GlobalSymbolID;
+use qbice::{
+    Decode, Encode, Identifiable, StableHash, storage::intern::Interned,
+};
 
 use crate::{
     generic_parameters::{GenericParameterID, get_generic_parameters},
     r#type::{
-        bound::BoundVariable, constructor::Application, context::TyContext,
-        inference::InferenceVariable, skolem::SkolemizedVariable,
+        bound::{Binder, BoundVariable},
+        constructor::{
+            AnonymousTraitInstance, Application, Constructor, FunctionPointer,
+            InstanceAssociated, Lifetime, Mutability, Primitive, Reference,
+            Symbolic, Tuple,
+        },
+        context::TyContext,
+        inference::InferenceVariable,
+        skolem::SkolemizedVariable,
     },
 };
 
@@ -46,6 +56,219 @@ pub enum Type {
 }
 
 impl Type {
+    /// Interns a type constructor application with the given arguments.
+    #[must_use]
+    pub fn new_application(
+        constructor: Constructor,
+        arguments: impl IntoIterator<Item = Interned<Self>>,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        engine.intern(Self::Application(Application::new(
+            constructor,
+            engine.intern_unsized(arguments.into_iter().collect::<Vec<_>>()),
+        )))
+    }
+
+    /// Interns a primitive type.
+    #[must_use]
+    pub fn new_primitive(
+        primitive: Primitive,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        Self::new_application(Constructor::Primitive(primitive), [], engine)
+    }
+
+    /// Interns a simple lifetime type.
+    #[must_use]
+    pub fn new_lifetime(
+        lifetime: Lifetime,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        Self::new_application(Constructor::Lifetime(lifetime), [], engine)
+    }
+
+    /// Interns a reference type.
+    #[must_use]
+    pub fn new_reference(
+        lifetime: Interned<Self>,
+        pointee: Interned<Self>,
+        mutability: Mutability,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        Self::new_application(
+            Constructor::Reference(Reference::new(mutability)),
+            [lifetime, pointee],
+            engine,
+        )
+    }
+
+    /// Interns an immutable reference type.
+    #[must_use]
+    pub fn new_immutable_reference(
+        lifetime: Interned<Self>,
+        pointee: Interned<Self>,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        Self::new_reference(lifetime, pointee, Mutability::Immutable, engine)
+    }
+
+    /// Interns a symbolic type with its generic arguments.
+    #[must_use]
+    pub fn new_symbolic(
+        symbol_id: GlobalSymbolID,
+        arguments: impl IntoIterator<Item = Interned<Self>>,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        Self::new_application(
+            Constructor::Symbolic(Symbolic::new(symbol_id)),
+            arguments,
+            engine,
+        )
+    }
+
+    /// Interns a tuple type without unpacked elements.
+    #[must_use]
+    pub fn new_tuple(
+        arguments: impl IntoIterator<Item = Interned<Self>>,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        Self::new_tuple_with_unpack(arguments, [], engine)
+    }
+
+    /// Interns a tuple type, including the positions of unpacked elements.
+    #[must_use]
+    pub fn new_tuple_with_unpack(
+        arguments: impl IntoIterator<Item = Interned<Self>>,
+        unpacked_positions: impl IntoIterator<Item = usize>,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        Self::new_application(
+            Constructor::Tuple(Tuple::new(engine.intern_unsized(
+                unpacked_positions.into_iter().collect::<Vec<_>>(),
+            ))),
+            arguments,
+            engine,
+        )
+    }
+
+    /// Interns a function pointer type without bound variables.
+    #[must_use]
+    pub fn new_function_pointer(
+        argument_types: impl IntoIterator<Item = Interned<Self>>,
+        return_type: Interned<Self>,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        Self::new_function_pointer_with_binder(
+            Binder::new(engine.intern_unsized(Vec::new())),
+            argument_types,
+            return_type,
+            engine,
+        )
+    }
+
+    /// Interns a function pointer type with the given binder.
+    #[must_use]
+    pub fn new_function_pointer_with_binder(
+        binder: Binder,
+        argument_types: impl IntoIterator<Item = Interned<Self>>,
+        return_type: Interned<Self>,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        Self::new_application(
+            Constructor::FunctionPointer(FunctionPointer::new(binder)),
+            argument_types.into_iter().chain(std::iter::once(return_type)),
+            engine,
+        )
+    }
+
+    /// Interns a function pointer type binding the given number of
+    /// higher-ranked lifetimes.
+    #[must_use]
+    pub fn new_function_pointer_with_higher_ranked_lifetimes(
+        higher_ranked_lifetime_count: usize,
+        argument_types: impl IntoIterator<Item = Interned<Self>>,
+        return_type: Interned<Self>,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        Self::new_function_pointer_with_binder(
+            Binder::new(engine.intern_unsized(vec![
+                kind::TyKind::Lifetime;
+                higher_ranked_lifetime_count
+            ])),
+            argument_types,
+            return_type,
+            engine,
+        )
+    }
+
+    /// Interns the anonymous instance of a trait.
+    #[must_use]
+    pub fn new_anonymous_trait_instance(
+        trait_id: GlobalSymbolID,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        Self::new_application(
+            Constructor::AnonymousTraitInstance(AnonymousTraitInstance::new(
+                trait_id,
+            )),
+            [],
+            engine,
+        )
+    }
+
+    /// Interns an instance-associated type or instance.
+    #[must_use]
+    pub fn new_instance_associated(
+        associated_id: GlobalSymbolID,
+        instance: Interned<Self>,
+        arguments: impl IntoIterator<Item = Interned<Self>>,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        Self::new_application(
+            Constructor::InstanceAssociated(InstanceAssociated::new(
+                associated_id,
+            )),
+            std::iter::once(instance).chain(arguments),
+            engine,
+        )
+    }
+
+    /// Interns a generic parameter type.
+    #[must_use]
+    pub fn new_generic_parameter(
+        parameter_id: GenericParameterID,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        engine.intern(Self::GenericParameter(parameter_id))
+    }
+
+    /// Interns an inference variable type.
+    #[must_use]
+    pub fn new_inference_variable(
+        variable: InferenceVariable,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        engine.intern(Self::InferenceVariable(variable))
+    }
+
+    /// Interns a bound variable type.
+    #[must_use]
+    pub fn new_bound_variable(
+        variable: BoundVariable,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        engine.intern(Self::BoundVariable(variable))
+    }
+
+    /// Interns a skolemized variable type.
+    #[must_use]
+    pub fn new_skolemized_variable(
+        variable: SkolemizedVariable,
+        engine: &TrackedEngine,
+    ) -> Interned<Self> {
+        engine.intern(Self::SkolemizedVariable(variable))
+    }
+
     pub async fn kind(
         &self,
         engine: &TrackedEngine,

--- a/compiler/semantic/type/src/type/constructor/destructure/test.rs
+++ b/compiler/semantic/type/src/type/constructor/destructure/test.rs
@@ -1,21 +1,10 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
-use std::sync::Arc;
-
-use pernixc_qbice::{Engine, InMemoryFactory, TrackedEngine};
-use qbice::{serialize::Plugin, stable_hash::SeededStableHasherBuilder};
+use pernixc_qbice::{
+    TrackedEngine, create_minimal_engine as create_test_engine,
+};
 
 use super::*;
 use crate::r#type::constructor::Primitive;
-
-fn intern_primitive(
-    primitive: Primitive,
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    engine.intern(Type::Application(Application {
-        constructor: Constructor::Primitive(primitive),
-        arguments: engine.intern_unsized(Vec::<Interned<Type>>::new()),
-    }))
-}
 
 fn primitive_application(
     primitive: Primitive,
@@ -33,13 +22,11 @@ fn tuple_type(
     unpacked_positions: &[usize],
     engine: &TrackedEngine,
 ) -> Interned<Type> {
-    engine.intern(Type::Application(Application {
-        constructor: Constructor::Tuple(Tuple {
-            unpacked_positions: engine
-                .intern_unsized(unpacked_positions.to_vec()),
-        }),
-        arguments: engine.intern_unsized(arguments.to_vec()),
-    }))
+    Type::new_tuple_with_unpack(
+        arguments.iter().cloned(),
+        unpacked_positions.iter().copied(),
+        engine,
+    )
 }
 
 fn tuple_application(
@@ -56,20 +43,6 @@ fn tuple_application(
     application.clone()
 }
 
-async fn create_test_engine() -> TrackedEngine {
-    Arc::new(
-        Engine::new_with(
-            Plugin::default(),
-            InMemoryFactory,
-            SeededStableHasherBuilder::new(0),
-        )
-        .await
-        .unwrap(),
-    )
-    .tracked()
-    .await
-}
-
 #[tokio::test]
 async fn destructure_same_non_tuple_constructor() {
     // lhs: int32<(bool, float32)>, rhs: int32<(usize, uint64)>
@@ -78,16 +51,16 @@ async fn destructure_same_non_tuple_constructor() {
     let lhs = primitive_application(
         Primitive::Int32,
         &[
-            intern_primitive(Primitive::Bool, &engine),
-            intern_primitive(Primitive::Float32, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Float32, &engine),
         ],
         &engine,
     );
     let rhs = primitive_application(
         Primitive::Int32,
         &[
-            intern_primitive(Primitive::Usize, &engine),
-            intern_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Usize, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
         ],
         &engine,
     );
@@ -97,12 +70,12 @@ async fn destructure_same_non_tuple_constructor() {
 
     assert_eq!(destructured, vec![
         (
-            intern_primitive(Primitive::Bool, &engine),
-            intern_primitive(Primitive::Usize, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Usize, &engine),
         ),
         (
-            intern_primitive(Primitive::Float32, &engine),
-            intern_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Float32, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
         ),
     ]);
 }
@@ -114,12 +87,12 @@ async fn destructure_different_non_tuple_constructors_fails() {
     let engine = create_test_engine().await;
     let lhs = primitive_application(
         Primitive::Int32,
-        &[intern_primitive(Primitive::Int32, &engine)],
+        &[Type::new_primitive(Primitive::Int32, &engine)],
         &engine,
     );
     let rhs = primitive_application(
         Primitive::Bool,
-        &[intern_primitive(Primitive::Int32, &engine)],
+        &[Type::new_primitive(Primitive::Int32, &engine)],
         &engine,
     );
 
@@ -134,14 +107,14 @@ async fn destructure_same_non_tuple_constructor_with_different_arity_fails() {
     let lhs = primitive_application(
         Primitive::Int32,
         &[
-            intern_primitive(Primitive::Bool, &engine),
-            intern_primitive(Primitive::Float32, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Float32, &engine),
         ],
         &engine,
     );
     let rhs = primitive_application(
         Primitive::Int32,
-        &[intern_primitive(Primitive::Usize, &engine)],
+        &[Type::new_primitive(Primitive::Usize, &engine)],
         &engine,
     );
 
@@ -155,16 +128,16 @@ async fn destructure_plain_tuples() {
     let engine = create_test_engine().await;
     let lhs = tuple_application(
         &[
-            intern_primitive(Primitive::Int32, &engine),
-            intern_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
         ],
         &[],
         &engine,
     );
     let rhs = tuple_application(
         &[
-            intern_primitive(Primitive::Float32, &engine),
-            intern_primitive(Primitive::Usize, &engine),
+            Type::new_primitive(Primitive::Float32, &engine),
+            Type::new_primitive(Primitive::Usize, &engine),
         ],
         &[],
         &engine,
@@ -175,12 +148,12 @@ async fn destructure_plain_tuples() {
 
     assert_eq!(destructured, vec![
         (
-            intern_primitive(Primitive::Int32, &engine),
-            intern_primitive(Primitive::Float32, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Float32, &engine),
         ),
         (
-            intern_primitive(Primitive::Bool, &engine),
-            intern_primitive(Primitive::Usize, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Usize, &engine),
         ),
     ]);
 }
@@ -192,19 +165,19 @@ async fn destructure_tuple_with_unpacked_right_hand_side() {
     let engine = create_test_engine().await;
     let lhs = tuple_application(
         &[
-            intern_primitive(Primitive::Int32, &engine),
-            intern_primitive(Primitive::Bool, &engine),
-            intern_primitive(Primitive::Float32, &engine),
-            intern_primitive(Primitive::Usize, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Float32, &engine),
+            Type::new_primitive(Primitive::Usize, &engine),
         ],
         &[],
         &engine,
     );
     let rhs = tuple_application(
         &[
-            intern_primitive(Primitive::Uint32, &engine),
-            intern_primitive(Primitive::Int64, &engine),
-            intern_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Uint32, &engine),
+            Type::new_primitive(Primitive::Int64, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
         ],
         &[1],
         &engine,
@@ -215,23 +188,23 @@ async fn destructure_tuple_with_unpacked_right_hand_side() {
 
     assert_eq!(destructured, vec![
         (
-            intern_primitive(Primitive::Int32, &engine),
-            intern_primitive(Primitive::Uint32, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Uint32, &engine),
         ),
         (
             tuple_type(
                 &[
-                    intern_primitive(Primitive::Bool, &engine),
-                    intern_primitive(Primitive::Float32, &engine),
+                    Type::new_primitive(Primitive::Bool, &engine),
+                    Type::new_primitive(Primitive::Float32, &engine),
                 ],
                 &[],
                 &engine,
             ),
-            intern_primitive(Primitive::Int64, &engine),
+            Type::new_primitive(Primitive::Int64, &engine),
         ),
         (
-            intern_primitive(Primitive::Usize, &engine),
-            intern_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Usize, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
         ),
     ]);
 }
@@ -243,19 +216,19 @@ async fn destructure_tuple_with_unpacked_left_hand_side() {
     let engine = create_test_engine().await;
     let lhs = tuple_application(
         &[
-            intern_primitive(Primitive::Uint32, &engine),
-            intern_primitive(Primitive::Int64, &engine),
-            intern_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Uint32, &engine),
+            Type::new_primitive(Primitive::Int64, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
         ],
         &[1],
         &engine,
     );
     let rhs = tuple_application(
         &[
-            intern_primitive(Primitive::Int32, &engine),
-            intern_primitive(Primitive::Bool, &engine),
-            intern_primitive(Primitive::Float32, &engine),
-            intern_primitive(Primitive::Usize, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Float32, &engine),
+            Type::new_primitive(Primitive::Usize, &engine),
         ],
         &[],
         &engine,
@@ -266,23 +239,23 @@ async fn destructure_tuple_with_unpacked_left_hand_side() {
 
     assert_eq!(destructured, vec![
         (
-            intern_primitive(Primitive::Uint32, &engine),
-            intern_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Uint32, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
         ),
         (
-            intern_primitive(Primitive::Int64, &engine),
+            Type::new_primitive(Primitive::Int64, &engine),
             tuple_type(
                 &[
-                    intern_primitive(Primitive::Bool, &engine),
-                    intern_primitive(Primitive::Float32, &engine),
+                    Type::new_primitive(Primitive::Bool, &engine),
+                    Type::new_primitive(Primitive::Float32, &engine),
                 ],
                 &[],
                 &engine,
             ),
         ),
         (
-            intern_primitive(Primitive::Uint64, &engine),
-            intern_primitive(Primitive::Usize, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Usize, &engine),
         ),
     ]);
 }
@@ -294,17 +267,17 @@ async fn destructure_tuple_with_unpacked_left_hand_side_to_empty_tuple() {
     let engine = create_test_engine().await;
     let lhs = tuple_application(
         &[
-            intern_primitive(Primitive::Uint32, &engine),
-            intern_primitive(Primitive::Int64, &engine),
-            intern_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Uint32, &engine),
+            Type::new_primitive(Primitive::Int64, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
         ],
         &[0],
         &engine,
     );
     let rhs = tuple_application(
         &[
-            intern_primitive(Primitive::Int32, &engine),
-            intern_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
         ],
         &[],
         &engine,
@@ -315,16 +288,16 @@ async fn destructure_tuple_with_unpacked_left_hand_side_to_empty_tuple() {
 
     assert_eq!(destructured, vec![
         (
-            intern_primitive(Primitive::Uint32, &engine),
+            Type::new_primitive(Primitive::Uint32, &engine),
             tuple_type(&[], &[], &engine),
         ),
         (
-            intern_primitive(Primitive::Int64, &engine),
-            intern_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Int64, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
         ),
         (
-            intern_primitive(Primitive::Uint64, &engine),
-            intern_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
         ),
     ]);
 }
@@ -336,18 +309,18 @@ async fn destructure_same_tuple_shape_pairs_element_wise() {
     let engine = create_test_engine().await;
     let lhs = tuple_application(
         &[
-            intern_primitive(Primitive::Int32, &engine),
-            intern_primitive(Primitive::Bool, &engine),
-            intern_primitive(Primitive::Float32, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Float32, &engine),
         ],
         &[1],
         &engine,
     );
     let rhs = tuple_application(
         &[
-            intern_primitive(Primitive::Uint32, &engine),
-            intern_primitive(Primitive::Int64, &engine),
-            intern_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Uint32, &engine),
+            Type::new_primitive(Primitive::Int64, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
         ],
         &[1],
         &engine,
@@ -358,16 +331,16 @@ async fn destructure_same_tuple_shape_pairs_element_wise() {
 
     assert_eq!(destructured, vec![
         (
-            intern_primitive(Primitive::Int32, &engine),
-            intern_primitive(Primitive::Uint32, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Uint32, &engine),
         ),
         (
-            intern_primitive(Primitive::Bool, &engine),
-            intern_primitive(Primitive::Int64, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Int64, &engine),
         ),
         (
-            intern_primitive(Primitive::Float32, &engine),
-            intern_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Float32, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
         ),
     ]);
 }
@@ -380,19 +353,19 @@ async fn destructure_grouped_tuple_preserves_other_unpacked_position() {
     let engine = create_test_engine().await;
     let lhs = tuple_application(
         &[
-            intern_primitive(Primitive::Int32, &engine),
-            intern_primitive(Primitive::Bool, &engine),
-            intern_primitive(Primitive::Float32, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Float32, &engine),
         ],
         &[1],
         &engine,
     );
     let rhs = tuple_application(
         &[
-            intern_primitive(Primitive::Uint32, &engine),
-            intern_primitive(Primitive::Int64, &engine),
-            intern_primitive(Primitive::Uint64, &engine),
-            intern_primitive(Primitive::Isize, &engine),
+            Type::new_primitive(Primitive::Uint32, &engine),
+            Type::new_primitive(Primitive::Int64, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Isize, &engine),
         ],
         &[2],
         &engine,
@@ -403,23 +376,23 @@ async fn destructure_grouped_tuple_preserves_other_unpacked_position() {
 
     assert_eq!(destructured, vec![
         (
-            intern_primitive(Primitive::Int32, &engine),
-            intern_primitive(Primitive::Uint32, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Uint32, &engine),
         ),
         (
-            intern_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
             tuple_type(
                 &[
-                    intern_primitive(Primitive::Int64, &engine),
-                    intern_primitive(Primitive::Uint64, &engine),
+                    Type::new_primitive(Primitive::Int64, &engine),
+                    Type::new_primitive(Primitive::Uint64, &engine),
                 ],
                 &[1],
                 &engine,
             ),
         ),
         (
-            intern_primitive(Primitive::Float32, &engine),
-            intern_primitive(Primitive::Isize, &engine),
+            Type::new_primitive(Primitive::Float32, &engine),
+            Type::new_primitive(Primitive::Isize, &engine),
         ),
     ]);
 }
@@ -432,19 +405,19 @@ async fn destructure_tuple_mismatch_fails_when_other_unpacked_is_outside_range()
     let engine = create_test_engine().await;
     let lhs = tuple_application(
         &[
-            intern_primitive(Primitive::Int32, &engine),
-            intern_primitive(Primitive::Bool, &engine),
-            intern_primitive(Primitive::Float32, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Float32, &engine),
         ],
         &[1],
         &engine,
     );
     let rhs = tuple_application(
         &[
-            intern_primitive(Primitive::Uint32, &engine),
-            intern_primitive(Primitive::Int64, &engine),
-            intern_primitive(Primitive::Uint64, &engine),
-            intern_primitive(Primitive::Isize, &engine),
+            Type::new_primitive(Primitive::Uint32, &engine),
+            Type::new_primitive(Primitive::Int64, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Isize, &engine),
         ],
         &[0],
         &engine,
@@ -460,18 +433,18 @@ async fn destructure_tuple_with_invalid_multiple_unpacked_positions_fails() {
     let engine = create_test_engine().await;
     let lhs = tuple_application(
         &[
-            intern_primitive(Primitive::Int32, &engine),
-            intern_primitive(Primitive::Bool, &engine),
-            intern_primitive(Primitive::Float32, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Float32, &engine),
         ],
         &[0, 2],
         &engine,
     );
     let rhs = tuple_application(
         &[
-            intern_primitive(Primitive::Uint32, &engine),
-            intern_primitive(Primitive::Int64, &engine),
-            intern_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Uint32, &engine),
+            Type::new_primitive(Primitive::Int64, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
         ],
         &[],
         &engine,
@@ -488,19 +461,19 @@ async fn destructure_tuple_with_ambiguous_unpacked_match_fails() {
     let engine = create_test_engine().await;
     let lhs = tuple_application(
         &[
-            intern_primitive(Primitive::Int32, &engine),
-            intern_primitive(Primitive::Bool, &engine),
-            intern_primitive(Primitive::Float32, &engine),
-            intern_primitive(Primitive::Usize, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Float32, &engine),
+            Type::new_primitive(Primitive::Usize, &engine),
         ],
         &[0],
         &engine,
     );
     let rhs = tuple_application(
         &[
-            intern_primitive(Primitive::Uint32, &engine),
-            intern_primitive(Primitive::Isize, &engine),
-            intern_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Uint32, &engine),
+            Type::new_primitive(Primitive::Isize, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
         ],
         &[2],
         &engine,

--- a/compiler/semantic/type/src/type/constructor/reduction/test.rs
+++ b/compiler/semantic/type/src/type/constructor/reduction/test.rs
@@ -16,10 +16,7 @@ use crate::{
         GenericParameters,
     },
     instance_associated,
-    r#type::{
-        Type,
-        constructor::{Primitive, Tuple},
-    },
+    r#type::{Type, constructor::Primitive},
 };
 
 const INSTANCE_SYMBOL_ID: GlobalSymbolID =
@@ -171,16 +168,16 @@ impl executor::Executor<instance_associated::Key, Config>
         engine: &TrackedEngine,
     ) -> Interned<Type> {
         match key.symbol_id {
-            INSTANCE_ASSOC_MIXED_SYMBOL_ID => tuple_type(
-                &[
-                    generic_parameter_type(
+            INSTANCE_ASSOC_MIXED_SYMBOL_ID => Type::new_tuple(
+                [
+                    Type::new_generic_parameter(
                         GenericParameterID::new(
                             INSTANCE_SYMBOL_ID,
                             ID::<GenericParameter>::new(0),
                         ),
                         engine,
                     ),
-                    generic_parameter_type(
+                    Type::new_generic_parameter(
                         GenericParameterID::new(
                             INSTANCE_ASSOC_MIXED_SYMBOL_ID,
                             ID::<GenericParameter>::new(0),
@@ -188,18 +185,19 @@ impl executor::Executor<instance_associated::Key, Config>
                         engine,
                     ),
                 ],
-                &[],
                 engine,
             ),
 
             INSTANCE_ASSOC_INSTANCE_PARAM_SYMBOL_ID
-            | INSTANCE_ASSOC_NON_TYPE_KIND_SYMBOL_ID => generic_parameter_type(
-                GenericParameterID::new(
-                    INSTANCE_SYMBOL_ID,
-                    ID::<GenericParameter>::new(0),
-                ),
-                engine,
-            ),
+            | INSTANCE_ASSOC_NON_TYPE_KIND_SYMBOL_ID => {
+                Type::new_generic_parameter(
+                    GenericParameterID::new(
+                        INSTANCE_SYMBOL_ID,
+                        ID::<GenericParameter>::new(0),
+                    ),
+                    engine,
+                )
+            }
 
             _ => panic!(
                 "unexpected instance associated symbol: {:?}",
@@ -227,56 +225,16 @@ async fn create_test_engine() -> TrackedEngine {
     Arc::new(engine).tracked().await
 }
 
-fn intern_primitive(
-    primitive: Primitive,
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    engine.intern(Type::Application(Application {
-        constructor: Constructor::Primitive(primitive),
-        arguments: engine.intern_unsized(Vec::<Interned<Type>>::new()),
-    }))
-}
-
-fn generic_parameter_type(
-    parameter_id: GenericParameterID,
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    engine.intern(Type::GenericParameter(parameter_id))
-}
-
-fn symbolic_type(
-    symbolic_id: GlobalSymbolID,
-    arguments: &[Interned<Type>],
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    engine.intern(Type::Application(Application {
-        constructor: Constructor::Symbolic(Symbolic { symbolic_id }),
-        arguments: engine.intern_unsized(arguments.to_vec()),
-    }))
-}
-
-fn tuple_type(
-    arguments: &[Interned<Type>],
-    unpacked_positions: &[usize],
-    engine: &TrackedEngine,
-) -> Interned<Type> {
-    engine.intern(Type::Application(Application {
-        constructor: Constructor::Tuple(Tuple {
-            unpacked_positions: engine
-                .intern_unsized(unpacked_positions.to_vec()),
-        }),
-        arguments: engine.intern_unsized(arguments.to_vec()),
-    }))
-}
-
 fn tuple_application(
     arguments: &[Interned<Type>],
     unpacked_positions: &[usize],
     engine: &TrackedEngine,
 ) -> Application {
-    let Type::Application(application) =
-        &*tuple_type(arguments, unpacked_positions, engine)
-    else {
+    let Type::Application(application) = &*Type::new_tuple_with_unpack(
+        (arguments).iter().cloned(),
+        (unpacked_positions).iter().copied(),
+        engine,
+    ) else {
         panic!("expected tuple application");
     };
 
@@ -309,17 +267,16 @@ async fn reduce_tuple_flattens_unpacked_tuple_argument() {
 
     let reduced = tuple_application(
         &[
-            intern_primitive(Primitive::Int32, &engine),
-            tuple_type(
-                &[
-                    intern_primitive(Primitive::Bool, &engine),
-                    intern_primitive(Primitive::Float32, &engine),
-                    intern_primitive(Primitive::Usize, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_tuple(
+                [
+                    Type::new_primitive(Primitive::Bool, &engine),
+                    Type::new_primitive(Primitive::Float32, &engine),
+                    Type::new_primitive(Primitive::Usize, &engine),
                 ],
-                &[],
                 &engine,
             ),
-            intern_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
         ],
         &[1],
         &engine,
@@ -330,16 +287,15 @@ async fn reduce_tuple_flattens_unpacked_tuple_argument() {
 
     assert_eq!(
         reduced,
-        tuple_type(
-            &[
-                intern_primitive(Primitive::Int32, &engine),
-                intern_primitive(Primitive::Bool, &engine),
-                intern_primitive(Primitive::Float32, &engine),
-                intern_primitive(Primitive::Usize, &engine),
-                intern_primitive(Primitive::Uint64, &engine),
+        Type::new_tuple(
+            [
+                Type::new_primitive(Primitive::Int32, &engine),
+                Type::new_primitive(Primitive::Bool, &engine),
+                Type::new_primitive(Primitive::Float32, &engine),
+                Type::new_primitive(Primitive::Usize, &engine),
+                Type::new_primitive(Primitive::Uint64, &engine),
             ],
-            &[],
-            &engine,
+            &engine
         )
     );
 }
@@ -350,9 +306,9 @@ async fn reduce_tuple_returns_none_for_non_tuple_unpacked_argument() {
 
     let original = tuple_application(
         &[
-            intern_primitive(Primitive::Int32, &engine),
-            intern_primitive(Primitive::Bool, &engine),
-            intern_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_primitive(Primitive::Bool, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
         ],
         &[1],
         &engine,
@@ -367,17 +323,17 @@ async fn reduce_tuple_preserves_inner_unpacked_positions() {
 
     let reduced = tuple_application(
         &[
-            intern_primitive(Primitive::Int32, &engine),
-            tuple_type(
-                &[
-                    intern_primitive(Primitive::Bool, &engine),
-                    intern_primitive(Primitive::Float32, &engine),
-                    intern_primitive(Primitive::Usize, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_tuple_with_unpack(
+                [
+                    Type::new_primitive(Primitive::Bool, &engine),
+                    Type::new_primitive(Primitive::Float32, &engine),
+                    Type::new_primitive(Primitive::Usize, &engine),
                 ],
-                &[1],
+                [1],
                 &engine,
             ),
-            intern_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
         ],
         &[1],
         &engine,
@@ -388,16 +344,16 @@ async fn reduce_tuple_preserves_inner_unpacked_positions() {
 
     assert_eq!(
         reduced,
-        tuple_type(
-            &[
-                intern_primitive(Primitive::Int32, &engine),
-                intern_primitive(Primitive::Bool, &engine),
-                intern_primitive(Primitive::Float32, &engine),
-                intern_primitive(Primitive::Usize, &engine),
-                intern_primitive(Primitive::Uint64, &engine),
+        Type::new_tuple_with_unpack(
+            [
+                Type::new_primitive(Primitive::Int32, &engine),
+                Type::new_primitive(Primitive::Bool, &engine),
+                Type::new_primitive(Primitive::Float32, &engine),
+                Type::new_primitive(Primitive::Usize, &engine),
+                Type::new_primitive(Primitive::Uint64, &engine),
             ],
-            &[2],
-            &engine,
+            [2],
+            &engine
         )
     );
 }
@@ -408,16 +364,15 @@ async fn reduce_tuple_shifts_later_unpacked_positions() {
 
     let reduced = tuple_application(
         &[
-            intern_primitive(Primitive::Int32, &engine),
-            tuple_type(
-                &[
-                    intern_primitive(Primitive::Bool, &engine),
-                    intern_primitive(Primitive::Float32, &engine),
+            Type::new_primitive(Primitive::Int32, &engine),
+            Type::new_tuple(
+                [
+                    Type::new_primitive(Primitive::Bool, &engine),
+                    Type::new_primitive(Primitive::Float32, &engine),
                 ],
-                &[],
                 &engine,
             ),
-            intern_primitive(Primitive::Uint64, &engine),
+            Type::new_primitive(Primitive::Uint64, &engine),
         ],
         &[1, 2],
         &engine,
@@ -428,15 +383,15 @@ async fn reduce_tuple_shifts_later_unpacked_positions() {
 
     assert_eq!(
         reduced,
-        tuple_type(
-            &[
-                intern_primitive(Primitive::Int32, &engine),
-                intern_primitive(Primitive::Bool, &engine),
-                intern_primitive(Primitive::Float32, &engine),
-                intern_primitive(Primitive::Uint64, &engine),
+        Type::new_tuple_with_unpack(
+            [
+                Type::new_primitive(Primitive::Int32, &engine),
+                Type::new_primitive(Primitive::Bool, &engine),
+                Type::new_primitive(Primitive::Float32, &engine),
+                Type::new_primitive(Primitive::Uint64, &engine),
             ],
-            &[3],
-            &engine,
+            [3],
+            &engine
         )
     );
 }
@@ -446,9 +401,9 @@ async fn reduce_instance_associated_substitutes_instance_generic_argument() {
     let engine = create_test_engine().await;
 
     let reduced = instance_associated_application(
-        symbolic_type(
+        Type::new_symbolic(
             INSTANCE_SYMBOL_ID,
-            &[intern_primitive(Primitive::Bool, &engine)],
+            [Type::new_primitive(Primitive::Bool, &engine)],
             &engine,
         ),
         TRAIT_ASSOC_INSTANCE_PARAM_SYMBOL_ID,
@@ -459,7 +414,7 @@ async fn reduce_instance_associated_substitutes_instance_generic_argument() {
     .await
     .unwrap();
 
-    assert_eq!(reduced, intern_primitive(Primitive::Bool, &engine));
+    assert_eq!(reduced, Type::new_primitive(Primitive::Bool, &engine));
 }
 
 #[tokio::test]
@@ -467,13 +422,13 @@ async fn reduce_instance_associated_substitutes_associated_generic_arguments() {
     let engine = create_test_engine().await;
 
     let reduced = instance_associated_application(
-        symbolic_type(
+        Type::new_symbolic(
             INSTANCE_SYMBOL_ID,
-            &[intern_primitive(Primitive::Bool, &engine)],
+            [Type::new_primitive(Primitive::Bool, &engine)],
             &engine,
         ),
         TRAIT_ASSOC_MIXED_SYMBOL_ID,
-        &[intern_primitive(Primitive::Uint64, &engine)],
+        &[Type::new_primitive(Primitive::Uint64, &engine)],
         &engine,
     )
     .reduce(&engine)
@@ -482,13 +437,12 @@ async fn reduce_instance_associated_substitutes_associated_generic_arguments() {
 
     assert_eq!(
         reduced,
-        tuple_type(
-            &[
-                intern_primitive(Primitive::Bool, &engine),
-                intern_primitive(Primitive::Uint64, &engine),
+        Type::new_tuple(
+            [
+                Type::new_primitive(Primitive::Bool, &engine),
+                Type::new_primitive(Primitive::Uint64, &engine),
             ],
-            &[],
-            &engine,
+            &engine
         )
     );
 }
@@ -498,9 +452,9 @@ async fn reduce_instance_associated_does_not_require_type_kind() {
     let engine = create_test_engine().await;
 
     let reduced = instance_associated_application(
-        symbolic_type(
+        Type::new_symbolic(
             INSTANCE_SYMBOL_ID,
-            &[intern_primitive(Primitive::Bool, &engine)],
+            [Type::new_primitive(Primitive::Bool, &engine)],
             &engine,
         ),
         TRAIT_ASSOC_NON_TYPE_KIND_SYMBOL_ID,
@@ -511,7 +465,7 @@ async fn reduce_instance_associated_does_not_require_type_kind() {
     .await
     .unwrap();
 
-    assert_eq!(reduced, intern_primitive(Primitive::Bool, &engine));
+    assert_eq!(reduced, Type::new_primitive(Primitive::Bool, &engine));
 }
 
 #[tokio::test]
@@ -520,9 +474,9 @@ async fn reduce_instance_associated_does_not_recurse_into_inner_instance() {
 
     let inner_instance =
         engine.intern(Type::Application(instance_associated_application(
-            symbolic_type(
+            Type::new_symbolic(
                 INSTANCE_SYMBOL_ID,
-                &[intern_primitive(Primitive::Bool, &engine)],
+                [Type::new_primitive(Primitive::Bool, &engine)],
                 &engine,
             ),
             TRAIT_ASSOC_RECURSIVE_INNER_SYMBOL_ID,


### PR DESCRIPTION
## Summary
- Update type constructor and destructure reduction behavior
- Adjust solver subtype, reduction, and outlives tests to match the new semantics
- Rework the base qbice and semantic type implementation to support the changes

## Testing
- Not run (not requested)